### PR TITLE
src/bytecode.c: include config.h to activate guards

### DIFF
--- a/src/bytecode.c
+++ b/src/bytecode.c
@@ -20,6 +20,10 @@
  * SOFTWARE.
  */
 
+#ifdef HAVE_CONFIG_H
+# include "config.h"
+#endif
+
 #include <colm/bytecode.h>
 
 #include <sys/types.h>


### PR DESCRIPTION
Fix compilation on Solaris, which needs sys/wait.h for macros like
WEXITSTATUS.

Signed-off-by: Fabian Groffen <grobian@gentoo.org>