### PR TITLE
Avoid runtests falling back to 2 jobs when /proc/cpuinfo lacks "cpu cores" on riscv64

### DIFF
--- a/test/runtests
+++ b/test/runtests
@@ -13,8 +13,11 @@ timed()
 		CORES=$(sysctl -n hw.physicalcpu)
 	fi
 
+	if ! echo $CORES | grep -q '^[1-9][0-9]*$'; then
+		CORES=$(nproc 2>/dev/null)
+	fi
 
-	if ! echo $CORES | grep -q '^[1-9][0-9]\?$'; then
+	if ! echo $CORES | grep -q '^[1-9][0-9]*$'; then
 		echo "warning: could not determine number of cores, using 2"
 		CORES=2
 	fi


### PR DESCRIPTION
This keeps the existing /proc/cpuinfo / sysctl probe first, then falls back to nproc if the result is invalid.

Also accepts more than 99 cores.