### PR TITLE
fix(grammar/go): capture full general_comment

### DIFF
--- a/grammar/go/go.lm
+++ b/grammar/go/go.lm
@@ -129,7 +129,7 @@ lex
 		/ '//' [^\n]* '\n' /
 	
 	rl general_comment
-		/ '/*' any* :> '*/'/
+		/ '/*' any* :>> '*/'/
 
 	rl pre_insert_semi /
 		( id -

--- a/grammar/go/test/input.go
+++ b/grammar/go/test/input.go
@@ -1,7 +1,7 @@
 ﻿a b c
 d e f
 treeß
-		foo then /**/
+		foo then /***/
 	bar  //ladkf
 	baz /*
 */end


### PR DESCRIPTION
The example Go grammar does not recognize valid block comments when they contain an asterisk.

This change fixes the grammar and makes a small change to the test suite for verification. It also agrees with the grammar that was output after building the full Colm distribution (in `share/colm-suite/rlhc-go.lm`), which uses:

```
token comment /
	'//' any* :> '\n' |
	'/*' any* :>> '*/'
/
```