### PR TITLE
Retain comments beyond the intermediate format.

### DIFF
--- a/src/cgil/ril.lm
+++ b/src/cgil/ril.lm
@@ -52,9 +52,6 @@ lex
 	token hex_number
 		/ '0x' [0-9a-fA-F]+ /
 
-	ignore
-		/ c_comment | cpp_comment /
-
 	token string
 		/ s_literal | d_literal /
 


### PR DESCRIPTION
This allows top-level Go comments from the original .rl files to be included in the resulting .go output

Test and expected result:

    % src/ragel/host-go/ragel-go examples/go/rpn.rl && head -5 examples/go/rpn.go
    // -*-go-*-
    //
    // Reverse Polish Notation Calculator
    // Copyright (c) 2010 J.A. Roberts Tunney
    // MIT License

The Go comments from `rpn.rl` are carried into the resulting `rpn.go` file.

Prior to this commit, top-level comments were stripped:

    % ragel-go examples/go/rpn.rl && head -5 examples/go/rpn.go
    package main

    import (
    "errors"
    "fmt"