### PR TITLE
Added Zig as a Raegal Producer/Consumer

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,7 +14,7 @@ This repository contains two closely related projects:
 
 - **Ragel**: A state machine compiler that generates executable finite state
   machines from regular expressions and state machine specifications. It targets
-  12+ languages: C, C++, D, Java, Ruby, C#, Go, OCaml, Rust, Julia, JavaScript,
+  13+ languages: C, C++, D, Java, Ruby, C#, Go, OCaml, Rust, Julia, Zig, JavaScript,
   GNU ASM x86-64, and Crack.
 
 Colm bootstraps Ragel -- Ragel's parser is written in Colm (`src/ragel/*.lm`).
@@ -64,6 +64,7 @@ ragel -T0 -o output.c input.rl
 ragel-c input.rl
 ragel-go input.rl
 ragel-rust input.rl
+ragel-zig input.rl
 ```
 
 ## Testing
@@ -118,9 +119,9 @@ cd test/trans.d && ../../test/runtests    # Translation tests
    - `rlreduce.lm`: Reduction rules
 
 3. **Host Language Targets** (src/ragel/host-*/):
-   - 12 directories: `host-asm/`, `host-c/`, `host-crack/`, `host-csharp/`,
+   - 13 directories: `host-asm/`, `host-c/`, `host-crack/`, `host-csharp/`,
      `host-d/`, `host-go/`, `host-java/`, `host-js/`, `host-julia/`,
-     `host-ocaml/`, `host-ruby/`, `host-rust/`
+     `host-ocaml/`, `host-ruby/`, `host-rust/`, `host-zig/`
    - Each contains language-specific parser grammar and code generation
 
 4. **Ragel Compilation Pipeline**:

--- a/README.md
+++ b/README.md
@@ -123,7 +123,8 @@ machines. The generated code can be output in a variety of host languages.
 
 ### Supported target languages
 
-C, C++, D, Java, Ruby, C#, Go, OCaml, Rust, Julia, JavaScript, GNU ASM x86-64, and Crack.
+C, C++, D, Java, Ruby, C#, Go, OCaml, Rust, Julia, Zig, JavaScript, GNU ASM x86-64, and
+Crack.
 
 ### Code generation backends
 
@@ -133,7 +134,8 @@ C, C++, D, Java, Ruby, C#, Go, OCaml, Rust, Julia, JavaScript, GNU ASM x86-64, a
 | `-F0`, `-F1` | Flat table-driven |
 | `-G0`, `-G1`, `-G2` | Goto-driven |
 
-Language-specific binaries are also available: `ragel-c`, `ragel-go`, `ragel-rust`, etc.
+Language-specific binaries are also available: `ragel-c`, `ragel-go`, `ragel-rust`,
+`ragel-zig`, etc.
 
 See the [`examples/`](examples/) directory for sample Ragel programs.
 

--- a/configure.ac
+++ b/configure.ac
@@ -184,6 +184,7 @@ AC_ARG_WITH(subject,
 		SUBJ_RAGEL_OCAML_BIN="$withval/bin/ragel-ocaml"
 		SUBJ_RAGEL_ASM_BIN="$withval/bin/ragel-asm"
 		SUBJ_RAGEL_RUST_BIN="$withval/bin/ragel-rust"
+		SUBJ_RAGEL_ZIG_BIN="$withval/bin/ragel-zig"
 		SUBJ_RAGEL_CRACK_BIN="$withval/bin/ragel-crack"
 		SUBJ_RAGEL_JULIA_BIN="$withval/bin/ragel-julia"
 	],
@@ -208,6 +209,7 @@ AC_ARG_WITH(subject,
 		SUBJ_RAGEL_OCAML_BIN='$(abs_top_builddir)/src/ragel/host-ocaml/ragel-ocaml'
 		SUBJ_RAGEL_ASM_BIN='$(abs_top_builddir)/src/ragel/host-asm/ragel-asm'
 		SUBJ_RAGEL_RUST_BIN='$(abs_top_builddir)/src/ragel/host-rust/ragel-rust'
+		SUBJ_RAGEL_ZIG_BIN='$(abs_top_builddir)/src/ragel/host-zig/ragel-zig'
 		SUBJ_RAGEL_CRACK_BIN='$(abs_top_builddir)/src/ragel/host-crack/ragel-crack'
 		SUBJ_RAGEL_JULIA_BIN='$(abs_top_builddir)/src/ragel/host-julia/ragel-julia'
 	]
@@ -229,6 +231,7 @@ SED_SUBST="$SED_SUBST -e 's|@SUBJ_RAGEL_GO_BIN@|${SUBJ_RAGEL_GO_BIN}|g'"
 SED_SUBST="$SED_SUBST -e 's|@SUBJ_RAGEL_OCAML_BIN@|${SUBJ_RAGEL_OCAML_BIN}|g'"
 SED_SUBST="$SED_SUBST -e 's|@SUBJ_RAGEL_ASM_BIN@|${SUBJ_RAGEL_ASM_BIN}|g'"
 SED_SUBST="$SED_SUBST -e 's|@SUBJ_RAGEL_RUST_BIN@|${SUBJ_RAGEL_RUST_BIN}|g'"
+SED_SUBST="$SED_SUBST -e 's|@SUBJ_RAGEL_ZIG_BIN@|${SUBJ_RAGEL_ZIG_BIN}|g'"
 SED_SUBST="$SED_SUBST -e 's|@SUBJ_RAGEL_CRACK_BIN@|${SUBJ_RAGEL_CRACK_BIN}|g'"
 SED_SUBST="$SED_SUBST -e 's|@SUBJ_RAGEL_JULIA_BIN@|${SUBJ_RAGEL_JULIA_BIN}|g'"
 
@@ -283,6 +286,7 @@ AC_PATH_PROG([GO_BIN], [go])
 AC_PATH_PROG([OCAML_BIN], [ocaml])
 AC_PATH_PROG([RUST_BIN], [rustc])
 AC_PATH_PROG([JULIA_BIN], [julia])
+AC_PATH_PROG([ZIG_BIN], [zig])
 
 dnl
 dnl Julia requires a large virtual address space. On systems where this is
@@ -365,6 +369,7 @@ SED_SUBST="$SED_SUBST -e 's|@GO_BIN@|${GO_BIN}|g'"
 SED_SUBST="$SED_SUBST -e 's|@OCAML_BIN@|${OCAML_BIN}|g'"
 SED_SUBST="$SED_SUBST -e 's|@RUST_BIN@|${RUST_BIN}|g'"
 SED_SUBST="$SED_SUBST -e 's|@JULIA_BIN@|${JULIA_BIN}|g'"
+SED_SUBST="$SED_SUBST -e 's|@ZIG_BIN@|${ZIG_BIN}|g'"
 SED_SUBST="$SED_SUBST -e 's|@GNUSTEP_CONFIG@|${GNUSTEP_CONFIG}|g'"
 SED_SUBST="$SED_SUBST -e 's|@ASM_BIN@|${ASM_BIN}|g'"
 
@@ -497,6 +502,7 @@ AC_CONFIG_FILES([
 	src/ragel/host-ocaml/Makefile
 	src/ragel/host-ruby/Makefile
 	src/ragel/host-rust/Makefile
+	src/ragel/host-zig/Makefile
 ])
 AC_OUTPUT
 

--- a/doc/ragel/ragel-guide.txt
+++ b/doc/ragel/ragel-guide.txt
@@ -46,7 +46,7 @@ regular expression. The single-expression model affords concise and elegant
 descriptions of languages and the generation of very simple, fast and robust
 code. Ragel compiles executable finite state machines from a high level regular
 language notation. Ragel targets C, C++, Objective-C, D, Go, GNU ASM x86-64,
-Java, Ruby, C#, OCaml, Crack, Rust, Julia and JavaScript
+Java, Ruby, C#, OCaml, Crack, Rust, Julia, Zig and JavaScript
 
 In addition to building state machines from regular expressions, Ragel allows
 the programmer to directly specify state machines with state charts. These two
@@ -112,7 +112,7 @@ machine representation and vice versa, the terms regular language and state
 machine (or just machine) will be used interchangeably in this document.
 
 Ragel outputs machines to C, C++, Objective-C, D, Go, GNU ASM x86-64, Java,
-Ruby, C#, OCaml, Crack, Rust, Julia and JavaScript code. The output is
+Ruby, C#, OCaml, Crack, Rust, Julia, Zig and JavaScript code. The output is
 designed to be generic and is not bound to any particular input or processing
 method. A Ragel machine expects to have data passed to it in buffer blocks.
 When there is no more input, the machine can be queried for acceptance.  In
@@ -2778,7 +2778,8 @@ language. The host-language options are:
 * `-A` for C# code.
 * `-O` for OCaml code.
 * `-U` for Rust
-* `-Y` for Julia 
+* `-B` for Zig
+* `-Y` for Julia
 * `-K` for Crack
 * `-P` for JavaScript
 
@@ -2860,6 +2861,7 @@ host languages. The following table shows what is supported.
 | Ruby       | `-T0 -T1 -F0 -F1`
 | OCaml      | `-T0 -T1 -F0 -F1`
 | Rust       | `-T0 -T1 -F0 -F1`
+| Zig        | `-T0 -T1 -F0 -F1 -G0 -G1 -G2`
 | Julia      | `-T0 -T1 -F0 -F1`
 | Crack      | `-T0 -T1 -F0 -F1`
 | JavaScript | `-T0 -T1 -F0 -F1`

--- a/doc/ragel/ragel.1.in
+++ b/doc/ragel/ragel.1.in
@@ -145,6 +145,9 @@ The host language is OCaml.
 .B -U
 The host language is Rust.
 .TP
+.B -B
+The host language is Zig.
+.TP
 .B -Y
 The host language is Julia.
 .TP

--- a/examples/zig/.gitignore
+++ b/examples/zig/.gitignore
@@ -1,0 +1,4 @@
+/atoi_zig
+/*.ri
+/*.o
+/*.zig

--- a/examples/zig/Makefile
+++ b/examples/zig/Makefile
@@ -1,0 +1,38 @@
+RAGEL_ZIG = ragel-zig
+ZIG = zig
+
+# Zig has no goto, but ragel-zig lowers ragel's goto backends onto a labeled
+# switch, so every code style works. -G2 is the fastest.
+STYLE ?= -G2
+
+ZIG_RAGEL_SOURCES = $(wildcard *.rl)
+EXECUTABLES = $(ZIG_RAGEL_SOURCES:.rl=_zig)
+INTERMEDIATES = $(ZIG_RAGEL_SOURCES:.rl=.zig)
+KEEP_INTERMEDIATES ?= 0
+
+ifneq ($(KEEP_INTERMEDIATES),0)
+    $(info [BUILD] Keeping intermediate sources)
+    .PRECIOUS: %.zig
+else
+    $(info [BUILD] Not keeping intermediate sources)
+    .INTERMEDIATE: %.zig
+endif
+
+$(info [BUILD] Executables: $(EXECUTABLES))
+
+all: $(EXECUTABLES)
+
+clean:
+	@echo [CLEAN]
+	find . -name '*.o' | xargs -n 1 rm -f
+	find . -name '*.ri' | xargs -n 1 rm -f
+	rm -f $(EXECUTABLES)
+	rm -f $(INTERMEDIATES)
+
+%_zig: %.zig
+	@echo [ZIG] $@
+	@$(ZIG) build-exe $< -femit-bin=$@ -OReleaseFast
+
+%.zig: %.rl
+	@echo [RAGEL] $@
+	@$(RAGEL_ZIG) $(STYLE) $< -o $*.zig

--- a/examples/zig/README.md
+++ b/examples/zig/README.md
@@ -1,0 +1,20 @@
+# Ragel examples for Zig
+
+This directory contains examples of building Zig parsers with Ragel.
+
+## Building
+
+Ragel source files use the `*.rl` extension. Build examples with:
+
+```bash
+make
+```
+
+The `STYLE` variable selects the code generation style. It defaults to `-G2`, which is the fastest. Zig supports all seven code styles (`-T0 -T1 -F0 -F1 -G0 -G1 -G2`) because `ragel-zig` lowers Ragel's goto backends onto a labeled switch.
+
+## Contributing
+
+Please consider the following when adding examples:
+
+1. One file — one example
+2. Use `*.rl` extension for your examples

--- a/examples/zig/atoi.rl
+++ b/examples/zig/atoi.rl
@@ -1,0 +1,89 @@
+// -*-zig-*-
+//
+// Convert a string to an integer.
+//
+// To compile:
+//
+//   ragel-zig -T0 -o atoi.zig atoi.rl
+//   zig build-exe atoi.zig
+//   ./atoi
+//
+// Zig has no goto, but ragel-zig lowers the goto backends onto a labeled
+// switch, so the -G0/-G1/-G2 styles work here too:
+//
+//   ragel-zig -G2 -o atoi.zig atoi.rl
+//
+// To show a diagram of your state machine:
+//
+//   ragel-zig -V -p -o atoi.dot atoi.rl
+//   xdot atoi.dot
+//
+
+const std = @import("std");
+
+%%{
+    machine atoi;
+    write data;
+}%%
+
+pub fn atoi(data: []const u8) i64 {
+    var cs: i32 = 0;
+    var p: i32 = 0;
+    var pe: i32 = @intCast(data.len);
+    var neg: bool = false;
+    var val: i64 = 0;
+    _ = &cs;
+    _ = &p;
+    _ = &pe;
+
+    %%{
+        action see_neg   { neg = true; }
+        action add_digit { val = val * 10 + (@as(i64, fc) - '0'); }
+
+        main :=
+            ( '-'@see_neg | '+' )? ( digit @add_digit )+
+            '\n'?
+            ;
+
+        write init;
+        write exec;
+    }%%
+
+    if (neg) {
+        val = -1 * val;
+    }
+
+    if (cs < atoi_first_final) {
+        std.debug.print("atoi: there was an error: {d} < {d}\n", .{ cs, atoi_first_final });
+    }
+
+    return val;
+}
+
+//////////////////////////////////////////////////////////////////////
+
+const AtoiTest = struct {
+    s: []const u8,
+    v: i64,
+};
+
+const atoi_tests = [_]AtoiTest{
+    .{ .s = "7", .v = 7 },
+    .{ .s = "666", .v = 666 },
+    .{ .s = "-666", .v = -666 },
+    .{ .s = "+666", .v = 666 },
+    .{ .s = "1234567890", .v = 1234567890 },
+    .{ .s = "+1234567890\n", .v = 1234567890 },
+};
+
+pub fn main() u8 {
+    var res: u8 = 0;
+    for (atoi_tests) |t| {
+        const got = atoi(t.s);
+        if (got != t.v) {
+            std.debug.print("FAIL atoi(\"{s}\") = {d}, want {d}\n", .{ t.s, got, t.v });
+            res = 1;
+        }
+    }
+    return res;
+}

--- a/full.Dockerfile
+++ b/full.Dockerfile
@@ -12,9 +12,16 @@ RUN apt-get update && apt-get install -y \
 	git libtool autoconf automake g++ gcc make \
 	wget clang gnupg gdc default-jdk \
 	ruby mono-mcs golang ocaml rustc julia \
-	curl xz-utils \
+	xz-utils \
 	gnustep-make python2 python-is-python2 \
 	libpcre3-dev libgnustep-base-dev
+
+# Zig is not packaged for focal.
+WORKDIR /devel/zig
+RUN wget https://ziglang.org/download/0.16.0/zig-x86_64-linux-0.16.0.tar.xz
+RUN mkdir -p /pkgs/zig && \
+	tar -xJf zig-x86_64-linux-0.16.0.tar.xz -C /pkgs/zig --strip-components=1
+ENV PATH=/pkgs/zig:$PATH
 
 WORKDIR /devel/llvm/
 RUN wget https://releases.llvm.org/3.3/llvm-3.3.src.tar.gz

--- a/full.Dockerfile
+++ b/full.Dockerfile
@@ -12,6 +12,7 @@ RUN apt-get update && apt-get install -y \
 	git libtool autoconf automake g++ gcc make \
 	wget clang gnupg gdc default-jdk \
 	ruby mono-mcs golang ocaml rustc julia \
+	curl xz-utils \
 	gnustep-make python2 python-is-python2 \
 	libpcre3-dev libgnustep-base-dev
 

--- a/src/cgil/Makefile.am
+++ b/src/cgil/Makefile.am
@@ -4,7 +4,8 @@ pkgdata_DATA = $(CGIL_FILES)
 
 CGIL_FILES = ril.lm rlhc-main.lm \
 	rlhc-c.lm rlhc-csharp.lm rlhc-go.lm rlhc-js.lm rlhc-ruby.lm \
-	rlhc-crack.lm rlhc-d.lm rlhc-java.lm rlhc-julia.lm rlhc-ocaml.lm rlhc-rust.lm
+	rlhc-crack.lm rlhc-d.lm rlhc-java.lm rlhc-julia.lm rlhc-ocaml.lm rlhc-rust.lm \
+	rlhc-zig.lm
 
 EXTRA_DIST = $(CGIL_FILES)
 

--- a/src/cgil/rlhc-zig.lm
+++ b/src/cgil/rlhc-zig.lm
@@ -1,11 +1,7 @@
 include 'ril.lm'
 
-#
-# Zig output relexer. Used only to re-indent the generated text by brace
-# depth. Note that Zig has no block comments, only line comments, and it
-# uses '\\' to introduce multiline string lines.
-#
-namespace out_zig
+# Zig multiline strings with '\\' require special handling.
+namespace zig_out
 	token _IN_ /''/
 	token _EX_ /''/
 
@@ -51,86 +47,41 @@ namespace out_zig
 	|	[string]
 	|	[`{ _IN_ item* _EX_ `} ]
 
-	def out_zig
+	def zig_out
 		[_IN_ _EX_ item*]
 end
 
 
 namespace zig_gen
 
-	global _: parser<out_zig::out_zig>
+	global _: parser<zig_out::zig_out>
 
-	#
-	# Zig has no goto. Ragel's goto backends emit a flat list of sibling
-	# labels with forward and backward jumps between them. We lower each
-	# such statement list into a labeled switch:
-	#
-	#     _sw0: switch ( @as( u32, 0 ) ) {
-	#         0 => { <stmts before first label> continue :_sw0 1; },
-	#         1 => { <stmts of label 1>        continue :_sw0 2; },
-	#         ...
-	#         else => unreachable,
-	#     }
-	#
-	# and every 'goto L' becomes 'continue :_sw0 <id of L>'. A compile-time
-	# known continue target is an unconditional jump straight to the prong;
-	# a runtime one gets its own dispatch at that site, which is what gives
-	# direct-threaded (computed goto) codegen.
-	#
-	# LabelSw maps a label name to the switch it lives in, LabelId maps it
-	# to its prong number within that switch.
-	#
+	# Lower goto to labeled switch: 'goto L' becomes 'continue :_sw<n> <id>'.
+	# LabelSw: label -> switch name. LabelId: label -> prong. Scoped by nesting depth.
 	global LabelSw: map<str, str> = new map<str, str>()
 	global LabelId: map<str, int> = new map<str, int>()
 	global SwCount: int = 0
 
-	#
-	# Number the labels directly contained in one statement list. Returns
-	# true if this level held any labels at all.
-	#
-	bool number_level( StmtList: stmt* )
+	# Claim labels for this level. insert() keeps first binding, so displace old.
+	str number_level( StmtList: stmt* )
 	{
-		Any: bool = false
-		for Stmt: stmt in repeat( StmtList ) {
-			if match Stmt [goto_label]
-				Any = true
-		}
-
-		if ( !Any )
-			return false
-
-		SwName: str = "_sw[SwCount]"
-		SwCount = SwCount + 1
-
+		SwName: str
 		N: int = 1
 		for Stmt: stmt in repeat( StmtList ) {
 			if match Stmt [L: goto_label] {
+				if ( !SwName ) {
+					SwName = "_sw[SwCount]"
+					SwCount = SwCount + 1
+				}
 				Name: str = $L.ident
+				LabelSw->remove( Name )
+				LabelId->remove( Name )
 				LabelSw->insert( Name, SwName )
 				LabelId->insert( Name, N )
 				N = N + 1
 			}
 		}
-		return true
-	}
-
-	#
-	# Walk every construct that can directly hold a statement list and
-	# number the labels found at that level.
-	#
-	void number_labels( Start: start )
-	{
-		number_level( Start._repeat_stmt )
-		for B: block in Start
-			number_level( B.StmtList )
-		for S: switch_stmt in Start
-			number_level( S._repeat_stmt )
-		for C: case_block in Start
-			number_level( C._repeat_stmt )
-		for D: default_block in Start
-			number_level( D._repeat_stmt )
-		for P: pat_block in Start
-			number_level( P._repeat_stmt )
+		return SwName
 	}
 
 	void tok_list( TL: host::tok* )
@@ -421,15 +372,14 @@ namespace zig_gen
 		}
 	}
 
-	#
-	# Zig rejects unreachable code outright, while C happily accepts it and
-	# Ragel does emit some (the start state action trails an unconditional
-	# goto, for one). Anything following an unconditional transfer in the
-	# same statement list has to be dropped.
-	#
+	# Zig rejects unreachable code; drop stmts after goto/break/continue.
 	bool is_transfer( Stmt: stmt )
 	{
 		if match Stmt [goto_stmt]
+			return true
+		if match Stmt [break_stmt]
+			return true
+		if match Stmt [continue_stmt]
 			return true
 		return false
 	}
@@ -443,11 +393,7 @@ namespace zig_gen
 			stmt( Stmt )
 	}
 
-	#
-	# Emit the body of a switch. RIL uses flat C-style 'case N:' labels
-	# with the arm's statements following, which we have to group into Zig
-	# prongs. Ragel's goto backends never rely on fallthrough.
-	#
+	# Transform flat C-style cases into Zig prongs (no fallthrough).
 	void switch_body( StmtList: stmt* )
 	{
 		Open: bool = false
@@ -507,10 +453,6 @@ namespace zig_gen
 		case [V: static_value] {
 			<<	"const [V.ident]: [type(V.type)] = [V.number];
 		}
-		case [ES: export_stmt]
-		{
-			<<	"pub const [ES.ident] = [number(ES.number)];
-		}
 		case [D: declaration]
 		{
 			# Declarations at a labelled level are hoisted by stmt_list;
@@ -520,6 +462,10 @@ namespace zig_gen
 		case [Index: index_stmt]
 		{
 			decl_out( Index.ident, 'i32', Index.opt_init )
+		}
+		case [ES: export_stmt]
+		{
+			<<	"pub const [ES.ident] = [number(ES.number)];
 		}
 		case [
 				'if' `( IfExpr: expr `) IfStmt: stmt
@@ -601,15 +547,13 @@ namespace zig_gen
 			<<	"[lvalue(AS.LValue) AS.assign_op expr(AS.expr)];
 		}
 		default {
+			# catches unspecified cases
 			<<	"[Stmt]
 		}
 	}
 
-	#
-	# A Zig 'var' that is never mutated, and any unused local, are compile
-	# errors. Discarding the address counts as both a use and a possible
-	# mutation, and does not survive into the optimised code.
-	#
+	# A 'var' never mutated, and any unused local, are compile errors.
+	# Discarding the address counts as both and does not survive optimisation.
 	void decl_out( Ident: ident, Ty: str, Init: opt_init )
 	{
 		<<	"var [Ident]: [Ty] = "
@@ -620,31 +564,21 @@ namespace zig_gen
 		<<	"_ = &[Ident];
 	}
 
+	# decl_out's no-init path, for hoisting out of a labeled level.
 	void hoist_decl( Ident: ident, Ty: str )
 	{
 		<<	"var [Ident]: [Ty] = 0;
 			"_ = &[Ident];
 	}
 
-	#
-	# Emit one statement list. If it directly contains labels the whole
-	# level becomes a labeled switch, with declarations hoisted out ahead
-	# of it (prongs are separate scopes) and their initialisers left
-	# behind as assignments so evaluation order is preserved.
-	#
+	# A level holding labels becomes a labeled switch. Declarations hoist out
+	# ahead of it, since prongs are separate scopes, leaving their
+	# initialisers behind as assignments to preserve evaluation order.
 	void stmt_list( StmtList: stmt* )
 	{
-		HasLabels: bool = false
-		FirstLabel: str
-		for Stmt: stmt in repeat( StmtList ) {
-			if match Stmt [L: goto_label] {
-				if ( !HasLabels )
-					FirstLabel = $L.ident
-				HasLabels = true
-			}
-		}
+		SwName: str = number_level( StmtList )
 
-		if ( !HasLabels ) {
+		if ( !SwName ) {
 			Dead: bool = false
 			for Stmt: stmt in repeat( StmtList ) {
 				if ( !Dead ) {
@@ -654,8 +588,6 @@ namespace zig_gen
 			}
 		}
 		else {
-			SwName: str = LabelSw->find( FirstLabel )
-
 			for Stmt: stmt in repeat( StmtList ) {
 				if match Stmt [D: declaration]
 					hoist_decl( D.ident, type_str(D.type) )
@@ -667,9 +599,12 @@ namespace zig_gen
 				"0 => {
 
 			Dead: bool = false
+			Id: int = 0
 			for Stmt: stmt in repeat( StmtList ) {
-				if match Stmt [L: goto_label] {
-					Id: int = LabelId->find( $L.ident )
+				if match Stmt [goto_label] {
+					# Prongs run in declaration order, matching the numbering
+					# number_level handed out.
+					Id = Id + 1
 					# Fall through into the next prong, unless control
 					# already left this one.
 					if ( !Dead )
@@ -703,18 +638,16 @@ namespace zig_gen
 
 	void trans( Output: stream, Start: start )
 	{
-		_ = new parser<out_zig::out_zig>()
+		_ = new parser<zig_out::zig_out>()
 		Input: _input = _->gets()
 		Input->auto_trim(true)
 
 		if ( Start.opt_bom.bom )
 			send Output [Start.opt_bom.bom]
 
-		number_labels( Start )
-
 		stmt_list( Start._repeat_stmt )
 
-		ZO: out_zig::out_zig = _->finish()
+		ZO: zig_out::zig_out = _->finish()
 
 		if ZO {
 			send Output

--- a/src/cgil/rlhc-zig.lm
+++ b/src/cgil/rlhc-zig.lm
@@ -1,0 +1,735 @@
+include 'ril.lm'
+
+#
+# Zig output relexer. Used only to re-indent the generated text by brace
+# depth. Note that Zig has no block comments, only line comments, and it
+# uses '\\' to introduce multiline string lines.
+#
+namespace out_zig
+	token _IN_ /''/
+	token _EX_ /''/
+
+	lex
+		token comment /
+			'//' any* :> '\n'
+		/
+
+		token ml_string /
+			'\\\\' [^\n]* '\n'
+		/
+
+		token id
+			/[a-zA-Z_][a-zA-Z_0-9]*/
+
+		token number /
+			[0-9]+
+		/
+
+		token symbol /
+			'!' | '#' | '$' | '%' | '&' | '(' | ')' | '*' |
+			'+' | ',' | '-' | '.' | '/' | ':' | ';' | '<' |
+			'=' | '>' | '?' | '@' | '[' | ']' | '^' | '|' |
+			'~' /
+
+		literal `{ `}
+
+		token string /
+				'"' ( [^"\\] | '\\' any ) * '"' |
+				"'" ( [^'\\] | '\\' any ) * "'"
+			/
+
+		ignore
+			/[ \t\v\r\n]+/
+	end
+
+	def item
+		[comment]
+	|	[ml_string]
+	|	[id]
+	|	[number]
+	|	[symbol]
+	|	[string]
+	|	[`{ _IN_ item* _EX_ `} ]
+
+	def out_zig
+		[_IN_ _EX_ item*]
+end
+
+
+namespace zig_gen
+
+	global _: parser<out_zig::out_zig>
+
+	#
+	# Zig has no goto. Ragel's goto backends emit a flat list of sibling
+	# labels with forward and backward jumps between them. We lower each
+	# such statement list into a labeled switch:
+	#
+	#     _sw0: switch ( @as( u32, 0 ) ) {
+	#         0 => { <stmts before first label> continue :_sw0 1; },
+	#         1 => { <stmts of label 1>        continue :_sw0 2; },
+	#         ...
+	#         else => unreachable,
+	#     }
+	#
+	# and every 'goto L' becomes 'continue :_sw0 <id of L>'. A compile-time
+	# known continue target is an unconditional jump straight to the prong;
+	# a runtime one gets its own dispatch at that site, which is what gives
+	# direct-threaded (computed goto) codegen.
+	#
+	# LabelSw maps a label name to the switch it lives in, LabelId maps it
+	# to its prong number within that switch.
+	#
+	global LabelSw: map<str, str> = new map<str, str>()
+	global LabelId: map<str, int> = new map<str, int>()
+	global SwCount: int = 0
+
+	#
+	# Number the labels directly contained in one statement list. Returns
+	# true if this level held any labels at all.
+	#
+	bool number_level( StmtList: stmt* )
+	{
+		Any: bool = false
+		for Stmt: stmt in repeat( StmtList ) {
+			if match Stmt [goto_label]
+				Any = true
+		}
+
+		if ( !Any )
+			return false
+
+		SwName: str = "_sw[SwCount]"
+		SwCount = SwCount + 1
+
+		N: int = 1
+		for Stmt: stmt in repeat( StmtList ) {
+			if match Stmt [L: goto_label] {
+				Name: str = $L.ident
+				LabelSw->insert( Name, SwName )
+				LabelId->insert( Name, N )
+				N = N + 1
+			}
+		}
+		return true
+	}
+
+	#
+	# Walk every construct that can directly hold a statement list and
+	# number the labels found at that level.
+	#
+	void number_labels( Start: start )
+	{
+		number_level( Start._repeat_stmt )
+		for B: block in Start
+			number_level( B.StmtList )
+		for S: switch_stmt in Start
+			number_level( S._repeat_stmt )
+		for C: case_block in Start
+			number_level( C._repeat_stmt )
+		for D: default_block in Start
+			number_level( D._repeat_stmt )
+		for P: pat_block in Start
+			number_level( P._repeat_stmt )
+	}
+
+	void tok_list( TL: host::tok* )
+	{
+		for Tok: host::tok in repeat(TL) {
+			switch Tok
+			case Stmt {
+				<<	"{
+					"	[stmt_list( StmtList )]
+					"}
+			}
+			case Expr {
+				<<	"([expr( Expr )])"
+			}
+			case Escape {
+				Str: str = $Tok
+				<<	"[Str.suffix( 1 )]"
+			}
+			default {
+				<<	[Tok]
+			}
+		}
+	}
+
+	void embedded_host( EmbeddedHost: embedded_host )
+	{
+		switch EmbeddedHost
+		case Expr
+		{
+			<<	['(' tok_list( TL ) ')']
+		}
+		case Stmt
+		{
+			<<	['{' tok_list( TL ) '}\n']
+		}
+		case Bare
+		{
+			<<	[tok_list( TL )]
+		}
+	}
+
+	void expr_factor( ExprFactor: expr_factor )
+	{
+		switch ExprFactor
+		case EmbeddedHost
+		{
+			<<	[embedded_host(embedded_host)]
+		}
+		case Paren
+		{
+			<<	['( ' expr(expr) ' )']
+		}
+		case [Base: expr_factor `[ Sub: expr `]]
+		{
+			# RIL is written with C precedence, where 'cast(uint)a[i]'
+			# casts the element. The grammar here is left recursive on the
+			# subscript, so it binds as '(cast(uint)a)[i]' instead. Undo
+			# that, otherwise we would be casting the array itself.
+			#
+			# Zig indexes with usize. Narrower unsigned types widen
+			# implicitly but signed ones do not, so cast every subscript.
+			if match Base [`cast `( T: type `) Inner: expr_factor] {
+				<<	["@as( " type(T) ", @intCast( "
+						expr_factor(Inner) '\[@intCast( ' expr( Sub ) ' )\]'
+						" ) )"]
+			}
+			else {
+				<<	[expr_factor(Base) '\[@intCast( ' expr( Sub ) ' )\]']
+			}
+		}
+		case ArraySubField
+		{
+			# Flatten a[i].f to a_f[i] for lvalue compatibility.
+			<<	[^ident '_' ^Field '\[@intCast( ' expr( expr ) ' )\]']
+		}
+		case Offset
+		{
+			# 'offset' yields a plain integer position, not a pointer.
+			<<	"@as( i32, @intCast( [expr(expr)] ) )"
+		}
+		case Deref
+		{
+			<<	[ base '\[@intCast( ' expr( expr ) ' )\]' ]
+		}
+		case True
+		{
+			<<	"true"
+		}
+		case False
+		{
+			<<	"false"
+		}
+		case Nil
+		{
+			<<	"0"
+		}
+		case Access
+		{
+			embedded_host(embedded_host)
+			expr_factor(_expr_factor)
+		}
+		case Cast
+		{
+			<<	["@as( " type(type) ", @intCast( " expr_factor(_expr_factor) " ) )" ]
+		}
+		default {
+			<<	[ExprFactor]
+		}
+	}
+
+	void lvalue( ExprFactor: lvalue )
+	{
+		switch ExprFactor
+		case [EH: embedded_host]
+		{
+			<<	[embedded_host(EH)]
+		}
+		case [LV: lvalue `[ TL: expr `]]
+		{
+			<<	[lvalue(LV) '\[@intCast( ' expr( TL ) ' )\]']
+		}
+		case [I: ident `[ E: expr `] `. F: ident]
+		{
+			<<	[^I '_' ^F '\[@intCast( ' expr( E ) ' )\]']
+		}
+		case [E1: embedded_host `-> E2: lvalue]
+		{
+			embedded_host( E1 )
+			lvalue( E2 )
+		}
+		default {
+			<<	[ExprFactor]
+		}
+	}
+
+	void expr_factor_op( ExprFactorOp: expr_factor_op )
+	{
+		switch ExprFactorOp
+		case [B: `! expr_factor_op]
+		{
+			<<	['!' expr_factor_op( _expr_factor_op )]
+		}
+		case [T: `~ expr_factor_op]
+		{
+			# Zig needs comptime_int width for bitwise NOT; cast to i32.
+			<<	['~@as( i32, @intCast( ' expr_factor_op( _expr_factor_op ) ' ) )']
+		}
+		case [expr_factor]
+		{
+			<<	[expr_factor( ExprFactorOp.expr_factor )]
+		}
+	}
+
+	void expr_bitwise( ExprBitwise: expr_bitwise )
+	{
+		switch ExprBitwise
+		case [expr_bitwise A: `& expr_factor_op]
+		{
+			<<	[expr_bitwise( _expr_bitwise ) ' & ' expr_factor_op( expr_factor_op )]
+		}
+		case [expr_factor_op]
+		{
+			<<	[expr_factor_op( ExprBitwise.expr_factor_op )]
+		}
+	}
+
+	void expr_mult( ExprMult: expr_mult )
+	{
+		switch ExprMult
+		case [expr_mult T: `* expr_bitwise]
+		{
+			<<	[expr_mult( _expr_mult ) ' * ' expr_bitwise( expr_bitwise )]
+		}
+		case [expr_bitwise]
+		{
+			<<	[expr_bitwise( expr_bitwise )]
+		}
+	}
+
+	void expr_add( ExprAdd: expr_add )
+	{
+		switch ExprAdd
+		case [expr_add Op: add_op expr_mult]
+		{
+			<<	[expr_add( _expr_add ) ' ' Op ' ' expr_mult( expr_mult )]
+		}
+		case [expr_mult]
+		{
+			<<	[expr_mult( ExprAdd.expr_mult )]
+		}
+	}
+
+	void expr_shift( ExprShift: expr_shift )
+	{
+		switch ExprShift
+		case [expr_shift Op: shift_op expr_add]
+		{
+			# Shift count needs Log2 type cast for safety.
+			<<	[expr_shift( _expr_shift ) ' ' Op ' @intCast( ' expr_add( expr_add ) ' )']
+		}
+		case [expr_add]
+		{
+			<<	[expr_add( expr_add )]
+		}
+	}
+
+	void test_op_out( Op: test_op )
+	{
+		# Zig spells the logical connectives 'and'/'or'.
+		switch Op
+		case [`&&]
+			<<	[' and ']
+		case [`||]
+			<<	[' or ']
+		default
+			<<	[' ' Op ' ']
+	}
+
+	void expr_test( ExprTest: expr_test )
+	{
+		switch ExprTest
+		case [expr_test Op: test_op expr_shift]
+		{
+			expr_test( _expr_test )
+			test_op_out( Op )
+			expr_shift( expr_shift )
+		}
+		case [expr_shift]
+		{
+			<<	[expr_shift( ExprTest.expr_shift )]
+		}
+	}
+
+	void expr( Expr: expr )
+	{
+		expr_test( Expr.expr_test )
+	}
+
+	str type_str( Type: type )
+	{
+		switch Type
+		case S8
+			return 'i8'
+		case S16
+			return 'i16'
+		case S32
+			return 'i32'
+		case S64
+			return 'i64'
+		case S128
+			return 'i128'
+		case "uint"
+			return 'u32'
+		case "int"
+			return 'i32'
+		case "char"
+			return 'u8'
+		case "byte"
+			return 'u8'
+		case "bool"
+			return 'bool'
+		default
+			# The host types are already spelled as Zig types.
+			return $Type
+	}
+
+	void type( Type: type )
+	{
+		<<	[type_str( Type )]
+	}
+
+	void number( Number: number )
+	{
+		switch Number
+		case Unsigned
+			<<	[uint]
+		case Char
+			<<	[uint]
+		default
+			<<	[Number]
+	}
+
+	void num_list( NumList: num_list )
+	{
+		number( NumList.number )
+		for CommaNum: comma_num in NumList {
+			<<	[', ' number( CommaNum.number )]
+		}
+	}
+
+	#
+	# Zig rejects unreachable code outright, while C happily accepts it and
+	# Ragel does emit some (the start state action trails an unconditional
+	# goto, for one). Anything following an unconditional transfer in the
+	# same statement list has to be dropped.
+	#
+	bool is_transfer( Stmt: stmt )
+	{
+		if match Stmt [goto_stmt]
+			return true
+		return false
+	}
+
+	# Ensure if/while bodies have braces.
+	void strip_block_stmt( Stmt: stmt )
+	{
+		if match Stmt [`{ StmtList: stmt* `}]
+			stmt_list(StmtList)
+		else
+			stmt( Stmt )
+	}
+
+	#
+	# Emit the body of a switch. RIL uses flat C-style 'case N:' labels
+	# with the arm's statements following, which we have to group into Zig
+	# prongs. Ragel's goto backends never rely on fallthrough.
+	#
+	void switch_body( StmtList: stmt* )
+	{
+		Open: bool = false
+		HasDefault: bool = false
+		Dead: bool = false
+
+		for Stmt: stmt in repeat( StmtList ) {
+			if match Stmt [CL: case_label] {
+				if Open
+					<<	"},
+				<<	"[expr( CL.expr )] => {
+				Open = true
+				Dead = false
+			}
+			elsif match Stmt [CB: case_block] {
+				if Open {
+					<<	"},
+					Open = false
+				}
+				<<	"[expr( CB.expr )] => {
+					"	[stmt_list( CB._repeat_stmt )]
+					"},
+			}
+			elsif match Stmt [DB: default_block] {
+				if Open {
+					<<	"},
+					Open = false
+				}
+				HasDefault = true
+				<<	"else => {
+					"	[stmt_list( DB._repeat_stmt )]
+					"},
+			}
+			elsif ( !Dead ) {
+				stmt( Stmt )
+				Dead = is_transfer( Stmt )
+			}
+		}
+
+		if Open
+			<<	"},
+
+		if ( !HasDefault )
+			<<	"else => {},
+	}
+
+	void stmt( Stmt: stmt )
+	{
+		switch Stmt
+		case [EH: embedded_host]
+		{
+			<<	[embedded_host(EH)]
+		}
+		case [A: static_array] {
+			<<	"const [A.ident] = \[_\][type(A.type)]{ [num_list(A.num_list)] };
+		}
+		case [V: static_value] {
+			<<	"const [V.ident]: [type(V.type)] = [V.number];
+		}
+		case [ES: export_stmt]
+		{
+			<<	"pub const [ES.ident] = [number(ES.number)];
+		}
+		case [D: declaration]
+		{
+			# Declarations at a labelled level are hoisted by stmt_list;
+			# this path covers every other scope.
+			decl_out( D.ident, type_str(D.type), D.opt_init )
+		}
+		case [Index: index_stmt]
+		{
+			decl_out( Index.ident, 'i32', Index.opt_init )
+		}
+		case [
+				'if' `( IfExpr: expr `) IfStmt: stmt
+				ElseIfClauseList: else_if_clause* ElseClauseOpt: else_clause?
+		] {
+			<<	"if ( [expr(IfExpr)] ) {
+				"	[strip_block_stmt(IfStmt)]
+				"}
+
+			for ElseIfClause: else_if_clause in repeat( ElseIfClauseList ) {
+				match ElseIfClause
+					['else if (' ElseIfExpr: expr ')' ElseIfStmt: stmt]
+
+				<<	"else if ( [expr(ElseIfExpr)] ) {
+					"	[strip_block_stmt(ElseIfStmt)]
+					"}
+			}
+
+			if ( match ElseClauseOpt ['else' ElseStmt: stmt] ) {
+				<<	"else {
+					"	[strip_block_stmt(ElseStmt)]
+					"}
+			}
+		}
+		case ["while ( TRUE )" WhileStmt: stmt] {
+			<<	"while ( true ) {
+				"	[strip_block_stmt(WhileStmt)]
+				"}
+		}
+		case [BL: break_label? 'while' '(' WhileExpr: expr ')' WhileStmt: stmt] {
+			if match BL [bl: break_label]
+				<<	"[bl.ident]: "
+			<<	"while ( [expr(WhileExpr)] ) {
+				"	[strip_block_stmt(WhileStmt)]
+				"}
+		}
+		case [`switch `( SwitchExpr: expr `) `{ StmtList: stmt* `}] {
+			<<	"switch ( [expr(SwitchExpr)] ) {
+				"	[switch_body( StmtList )]
+				"}
+		}
+		case [G: goto_stmt]
+		{
+			Name: str = $G.ident
+			SwName: str = LabelSw->find( Name )
+			Id: int = LabelId->find( Name )
+			if SwName
+				<<	"continue :[SwName] [Id];
+			else
+				# A label we never numbered; should not happen.
+				<<	"unreachable;
+		}
+		case [goto_label]
+		{
+			# Consumed by stmt_list when it builds the labeled switch.
+		}
+		case [`continue CL: ident `;] {
+			<<	"continue :[CL];
+		}
+		case [`break BL: ident `;] {
+			<<	"break :[BL];
+		}
+		case [`continue `;] {
+			<<	"continue;
+		}
+		case [`break `;] {
+			<<	"break;
+		}
+		case [ExprExpr: expr `;] {
+			<<	[expr(ExprExpr) ';']
+		}
+		case [B: block] {
+			<<	"{
+				"	[stmt_list(B.StmtList)]
+				"}
+		}
+		case [AS: assign_stmt]
+		{
+			<<	"[lvalue(AS.LValue) AS.assign_op expr(AS.expr)];
+		}
+		default {
+			<<	"[Stmt]
+		}
+	}
+
+	#
+	# A Zig 'var' that is never mutated, and any unused local, are compile
+	# errors. Discarding the address counts as both a use and a possible
+	# mutation, and does not survive into the optimised code.
+	#
+	void decl_out( Ident: ident, Ty: str, Init: opt_init )
+	{
+		<<	"var [Ident]: [Ty] = "
+		if match Init ['=' E: expr]
+			<<	"[expr(E)];
+		else
+			<<	"0;
+		<<	"_ = &[Ident];
+	}
+
+	void hoist_decl( Ident: ident, Ty: str )
+	{
+		<<	"var [Ident]: [Ty] = 0;
+			"_ = &[Ident];
+	}
+
+	#
+	# Emit one statement list. If it directly contains labels the whole
+	# level becomes a labeled switch, with declarations hoisted out ahead
+	# of it (prongs are separate scopes) and their initialisers left
+	# behind as assignments so evaluation order is preserved.
+	#
+	void stmt_list( StmtList: stmt* )
+	{
+		HasLabels: bool = false
+		FirstLabel: str
+		for Stmt: stmt in repeat( StmtList ) {
+			if match Stmt [L: goto_label] {
+				if ( !HasLabels )
+					FirstLabel = $L.ident
+				HasLabels = true
+			}
+		}
+
+		if ( !HasLabels ) {
+			Dead: bool = false
+			for Stmt: stmt in repeat( StmtList ) {
+				if ( !Dead ) {
+					stmt( Stmt )
+					Dead = is_transfer( Stmt )
+				}
+			}
+		}
+		else {
+			SwName: str = LabelSw->find( FirstLabel )
+
+			for Stmt: stmt in repeat( StmtList ) {
+				if match Stmt [D: declaration]
+					hoist_decl( D.ident, type_str(D.type) )
+				elsif match Stmt [I: index_stmt]
+					hoist_decl( I.ident, 'i32' )
+			}
+
+			<<	"[SwName]: switch ( @as( u32, 0 ) ) {
+				"0 => {
+
+			Dead: bool = false
+			for Stmt: stmt in repeat( StmtList ) {
+				if match Stmt [L: goto_label] {
+					Id: int = LabelId->find( $L.ident )
+					# Fall through into the next prong, unless control
+					# already left this one.
+					if ( !Dead )
+						<<	"continue :[SwName] [Id];
+					<<	"},
+						"[Id] => {
+					Dead = false
+				}
+				elsif Dead {
+					# Unreachable; Zig would reject it.
+				}
+				elsif match Stmt [D: declaration] {
+					if match D.opt_init ['=' E: expr]
+						<<	"[D.ident] = [expr(E)];
+				}
+				elsif match Stmt [I: index_stmt] {
+					if match I.opt_init ['=' E: expr]
+						<<	"[I.ident] = [expr(E)];
+				}
+				else {
+					stmt( Stmt )
+					Dead = is_transfer( Stmt )
+				}
+			}
+
+			<<	"},
+				"else => unreachable,
+				"}
+		}
+	}
+
+	void trans( Output: stream, Start: start )
+	{
+		_ = new parser<out_zig::out_zig>()
+		Input: _input = _->gets()
+		Input->auto_trim(true)
+
+		if ( Start.opt_bom.bom )
+			send Output [Start.opt_bom.bom]
+
+		number_labels( Start )
+
+		stmt_list( Start._repeat_stmt )
+
+		ZO: out_zig::out_zig = _->finish()
+
+		if ZO {
+			send Output
+				[ZO]
+		}
+		else {
+			send stderr
+				"failed to parse output: [_->error]
+		}
+	}
+end
+
+void trans( Output: stream, Start: start )
+{
+	zig_gen::trans( Output, Start )
+}
+
+include 'rlhc-main.lm'

--- a/src/cgil/test/.gitignore
+++ b/src/cgil/test/.gitignore
@@ -45,3 +45,4 @@
 /cgil-rust.c
 /cgil-zig.c
 /cgil-rust.dSYM
+/cgil-zig.dSYM

--- a/src/cgil/test/.gitignore
+++ b/src/cgil/test/.gitignore
@@ -41,5 +41,7 @@
 /cgil-ruby.c
 /cgil-ruby.dSYM
 /cgil-rust
+/cgil-zig
 /cgil-rust.c
+/cgil-zig.c
 /cgil-rust.dSYM

--- a/src/cgil/test/.gitignore
+++ b/src/cgil/test/.gitignore
@@ -41,8 +41,8 @@
 /cgil-ruby.c
 /cgil-ruby.dSYM
 /cgil-rust
-/cgil-zig
 /cgil-rust.c
-/cgil-zig.c
 /cgil-rust.dSYM
+/cgil-zig
+/cgil-zig.c
 /cgil-zig.dSYM

--- a/src/cgil/test/Makefile.am
+++ b/src/cgil/test/Makefile.am
@@ -1,7 +1,7 @@
 bin_PROGRAMS = \
 	cgil-c cgil-crack cgil-csharp cgil-d \
 	cgil-go cgil-java cgil-js cgil-julia \
-	cgil-ocaml cgil-ruby cgil-rust
+	cgil-ocaml cgil-ruby cgil-rust cgil-zig
 
 check_SCRIPTS = subject.mk subject.sh runtests
 
@@ -53,4 +53,7 @@ cgil-ruby$(EXEEXT): $(top_srcdir)/src/cgil/rlhc-ruby.lm $(top_srcdir)/src/cgil/r
 	$(SUBJ_COLM_BIN) -B '$(top_builddir)' -I .. -o $@ $<
 
 cgil-rust$(EXEEXT): $(top_srcdir)/src/cgil/rlhc-rust.lm $(top_srcdir)/src/cgil/ril.lm $(SUBJ_COLM_BIN)
+	$(SUBJ_COLM_BIN) -B '$(top_builddir)' -I .. -o $@ $<
+
+cgil-zig$(EXEEXT): $(top_srcdir)/src/cgil/rlhc-zig.lm $(top_srcdir)/src/cgil/ril.lm $(SUBJ_COLM_BIN)
 	$(SUBJ_COLM_BIN) -B '$(top_builddir)' -I .. -o $@ $<

--- a/src/cgil/test/cases/test-zig-00.ri
+++ b/src/cgil/test/cases/test-zig-00.ri
@@ -1,0 +1,6 @@
+host( "tmp.rl", 5 ) ${
+	${
+		host( "-", 1 ) ={ stackvar }=[top] = cs;
+		cs = host( "-", 1 ) ={ stackvar }=[top];
+	}$
+}$

--- a/src/cgil/test/cases/test-zig-00.zig
+++ b/src/cgil/test/cases/test-zig-00.zig
@@ -1,0 +1,7 @@
+{{
+		(stackvar )[@intCast( top )]=cs;
+		cs=(stackvar )[@intCast( top )];
+		
+	}
+	
+}

--- a/src/cgil/test/cases/test-zig-01.ri
+++ b/src/cgil/test/cases/test-zig-01.ri
@@ -1,0 +1,10 @@
+{
+	_resume: {}
+	goto _out;
+	_out: {}
+}
+{
+	_resume: {}
+	goto _out;
+	_out: {}
+}

--- a/src/cgil/test/cases/test-zig-01.zig
+++ b/src/cgil/test/cases/test-zig-01.zig
@@ -1,0 +1,40 @@
+{
+	_sw0: switch ( @as( u32, 0 ) ) {
+		0 => {
+			continue :_sw0 1;
+		},
+		1 => {
+			{
+			
+			}
+			continue :_sw0 2;
+		},
+		2 => {
+			{
+			
+			}
+		},
+		else => unreachable,
+	}
+	
+}
+{
+	_sw1: switch ( @as( u32, 0 ) ) {
+		0 => {
+			continue :_sw1 1;
+		},
+		1 => {
+			{
+			
+			}
+			continue :_sw1 2;
+		},
+		2 => {
+			{
+			
+			}
+		},
+		else => unreachable,
+	}
+	
+}

--- a/src/cgil/test/runtests.in
+++ b/src/cgil/test/runtests.in
@@ -4,7 +4,7 @@ set -x -e
 
 shopt -s nullglob
 
-LANGUAGES="c crack csharp d go java js julia ocaml ruby rust"
+LANGUAGES="c crack csharp d go java js julia ocaml ruby rust zig"
 
 for LANG in $LANGUAGES; do
 	for RI in cases/test-$LANG-??.ri; do

--- a/src/libfsm/CMakeLists.txt
+++ b/src/libfsm/CMakeLists.txt
@@ -119,7 +119,8 @@ add_executable(ragel
 target_link_libraries(ragel libragel libfsm)
 
 foreach(_SUBDIR host-ruby host-asm host-julia host-ocaml host-c host-d
-		host-csharp host-go host-java host-rust host-crack host-js)
+		host-csharp host-go host-java host-rust host-crack host-js
+		host-zig)
 	add_subdirectory(${_SUBDIR})
 endforeach()
 

--- a/src/ragel/CMakeLists.txt
+++ b/src/ragel/CMakeLists.txt
@@ -119,7 +119,8 @@ add_executable(ragel
 target_link_libraries(ragel libragel libfsm)
 
 foreach(_SUBDIR host-ruby host-asm host-julia host-ocaml host-c host-d
-		host-csharp host-go host-java host-rust host-crack host-js)
+		host-csharp host-go host-java host-rust host-crack host-js
+		host-zig)
 	add_subdirectory(${_SUBDIR})
 endforeach()
 

--- a/src/ragel/Makefile.am
+++ b/src/ragel/Makefile.am
@@ -1,5 +1,6 @@
 SUBDIRS = . host-ruby host-asm host-julia host-ocaml host-c \
-	host-d host-csharp host-go host-java host-rust host-crack host-js
+	host-d host-csharp host-go host-java host-rust host-crack host-js \
+	host-zig
 
 # libragel contains the parse tree and other parsing support code. Everything
 # except the reducers, which are specific to the frontends.

--- a/src/ragel/host-zig/.gitignore
+++ b/src/ragel/host-zig/.gitignore
@@ -1,0 +1,13 @@
+/Makefile
+/Makefile.in
+/.deps
+/.libs
+/ragel-zig
+/ragel-zig.exe
+/rlhc.c
+/rlparse.pack
+/rlparse.c
+/rlreduce.cc
+
+/CMakeFiles
+/cmake_install.cmake

--- a/src/ragel/host-zig/CMakeLists.txt
+++ b/src/ragel/host-zig/CMakeLists.txt
@@ -1,0 +1,34 @@
+add_custom_command(OUTPUT
+	"${CMAKE_CURRENT_BINARY_DIR}/rlparse.c"
+	"${CMAKE_CURRENT_BINARY_DIR}/rlreduce.cc"
+	DEPENDS rlparse.lm
+	COMMAND colm::colm
+	ARGS -I.. -c -b rlparseZig
+	-o "${CMAKE_CURRENT_BINARY_DIR}/rlparse.c"
+	-m "${CMAKE_CURRENT_BINARY_DIR}/rlreduce.cc"
+	rlparse.lm
+	WORKING_DIRECTORY "${CMAKE_CURRENT_LIST_DIR}")
+
+add_custom_command(OUTPUT
+	"${CMAKE_CURRENT_BINARY_DIR}/rlhc.c"
+	DEPENDS rlhc.lm
+	COMMAND colm::colm
+	ARGS -I.. -c -b rlhcZig
+	-o "${CMAKE_CURRENT_BINARY_DIR}/rlhc.c"
+	rlhc.lm
+	WORKING_DIRECTORY "${CMAKE_CURRENT_LIST_DIR}")
+
+add_executable(ragel-zig main.cc
+	"${CMAKE_CURRENT_BINARY_DIR}/rlhc.c"
+	"${CMAKE_CURRENT_BINARY_DIR}/rlparse.c"
+	"${CMAKE_CURRENT_BINARY_DIR}/rlreduce.cc")
+
+target_link_libraries(ragel-zig PRIVATE libragel libfsm)
+
+if(${PROJECT_NAME}_MAKE_INSTALL)
+	install(TARGETS ragel-zig
+		EXPORT ${_PACKAGE_NAME}-targets
+		RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}"
+		LIBRARY DESTINATION "${CMAKE_INSTALL_LIBDIR}"
+		ARCHIVE DESTINATION "${CMAKE_INSTALL_LIBDIR}")
+endif()

--- a/src/ragel/host-zig/Makefile.am
+++ b/src/ragel/host-zig/Makefile.am
@@ -1,0 +1,28 @@
+bin_PROGRAMS = ragel-zig
+
+ragel_zig_CPPFLAGS = -I$(top_srcdir)/src/aapl -I$(top_srcdir)/src/ragel -I$(top_srcdir)/src/include
+
+dist_ragel_zig_SOURCES = main.cc rlhc.c
+
+nodist_ragel_zig_SOURCES = \
+	rlparse.c rlreduce.cc
+
+ragel_zig_LDADD = $(LIBFSM_LA) $(LIBCOLM_LA) ../libragel.la
+
+BUILT_SOURCES = rlparse.c rlreduce.cc rlhc.c
+
+EXTRA_DIST = rlparse.lm
+
+LM_DEPS = ../ragel.lm ../rlreduce.lm
+
+rlparse.pack: rlparse.lm $(COLM) $(COLM_WRAP) $(LM_DEPS)
+	$(COLM_WRAP) -c -I .. -b rlparseZig -o $@ -p rlparse.c -m rlreduce.cc $<
+
+rlparse.c: rlparse.pack
+	$(COLM_WRAP) -o $@ $<
+
+rlreduce.cc: rlparse.pack
+	$(COLM_WRAP) -o $@ $<
+
+rlhc.c: $(COLM_SHARE)/rlhc-zig.lm $(COLM_SHARE)/ril.lm $(COLM) $(COLM_WRAP)
+	$(COLM) -c -I $(COLM_SHARE) -b rlhcZig -o $@ $<

--- a/src/ragel/host-zig/main.cc
+++ b/src/ragel/host-zig/main.cc
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2001-2018 Adrian Thurston <thurston@colm.net>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to
+ * deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+ * sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include "inputdata.h"
+#include "nragel.h"
+
+extern struct colm_sections rlparseZig;
+extern struct colm_sections rlhcZig;
+
+/*
+ * Zig
+ */
+
+const char *defaultOutFnZig( const char *inputFileName )
+{
+	return fileNameFromStem( inputFileName, ".zig" );
+}
+
+HostType hostTypesZig[] =
+{
+	{ "u8",    0,  "uint8",   false,  true,  false,  0, 0,                    U8BIT_MIN,  U8BIT_MAX,   1 },
+	{ "i8",    0,  "int8",    true,   true,  false,  S8BIT_MIN,  S8BIT_MAX,   0, 0,                    1 },
+	{ "u16",   0,  "uint16",  false,  true,  false,  0, 0,                    U16BIT_MIN, U16BIT_MAX,  2 },
+	{ "i16",   0,  "int16",   true,   true,  false,  S16BIT_MIN, S16BIT_MAX,  0, 0,                    2 },
+	{ "u32",   0,  "uint32",  false,  true,  false,  0, 0,                    U32BIT_MIN, U32BIT_MAX,  4 },
+	{ "i32",   0,  "int32",   true,   true,  false,  S32BIT_MIN, S32BIT_MAX,  0, 0,                    4 },
+	{ "u64",   0,  "uint64",  false,  true,  false,  0, 0,                    U64BIT_MIN, U64BIT_MAX,  8 },
+	{ "i64",   0,  "int64",   true,   true,  false,  S64BIT_MIN, S64BIT_MAX,  0, 0,                    8 },
+};
+
+/* Zig uses labeled switch for goto emulation. Supports -G0/-G1/-G2 styles. */
+const HostLang hostLangZig =
+{
+	hostTypesZig,
+	8,
+	0,
+	false,
+	false,    /* loopLabels */
+	Translated,
+	GotoFeature,
+	&makeCodeGen,
+	&defaultOutFnZig,
+	&genLineDirectiveTrans
+};
+
+
+int main( int argc, const char **argv )
+{
+	InputData id( &hostLangZig, &rlparseZig, &rlhcZig );
+	return id.rlhcMain( argc, argv );
+}

--- a/src/ragel/host-zig/main.cc
+++ b/src/ragel/host-zig/main.cc
@@ -37,14 +37,14 @@ const char *defaultOutFnZig( const char *inputFileName )
 
 HostType hostTypesZig[] =
 {
-	{ "u8",    0,  "uint8",   false,  true,  false,  0, 0,                    U8BIT_MIN,  U8BIT_MAX,   1 },
-	{ "i8",    0,  "int8",    true,   true,  false,  S8BIT_MIN,  S8BIT_MAX,   0, 0,                    1 },
-	{ "u16",   0,  "uint16",  false,  true,  false,  0, 0,                    U16BIT_MIN, U16BIT_MAX,  2 },
-	{ "i16",   0,  "int16",   true,   true,  false,  S16BIT_MIN, S16BIT_MAX,  0, 0,                    2 },
-	{ "u32",   0,  "uint32",  false,  true,  false,  0, 0,                    U32BIT_MIN, U32BIT_MAX,  4 },
-	{ "i32",   0,  "int32",   true,   true,  false,  S32BIT_MIN, S32BIT_MAX,  0, 0,                    4 },
-	{ "u64",   0,  "uint64",  false,  true,  false,  0, 0,                    U64BIT_MIN, U64BIT_MAX,  8 },
-	{ "i64",   0,  "int64",   true,   true,  false,  S64BIT_MIN, S64BIT_MAX,  0, 0,                    8 },
+	{ "u8",  0, "uint8",  false, true, false, 0, 0,                  U8BIT_MIN,  U8BIT_MAX,  1 },
+	{ "i8",  0, "int8",   true,  true, false, S8BIT_MIN,  S8BIT_MAX,  0, 0,                  1 },
+	{ "u16", 0, "uint16", false, true, false, 0, 0,                  U16BIT_MIN, U16BIT_MAX, 2 },
+	{ "i16", 0, "int16",  true,  true, false, S16BIT_MIN, S16BIT_MAX, 0, 0,                  2 },
+	{ "u32", 0, "uint32", false, true, false, 0, 0,                  U32BIT_MIN, U32BIT_MAX, 4 },
+	{ "i32", 0, "int32",  true,  true, false, S32BIT_MIN, S32BIT_MAX, 0, 0,                  4 },
+	{ "u64", 0, "uint64", false, true, false, 0, 0,                  U64BIT_MIN, U64BIT_MAX, 8 },
+	{ "i64", 0, "int64",  true,  true, false, S64BIT_MIN, S64BIT_MAX, 0, 0,                  8 },
 };
 
 /* Zig uses labeled switch for goto emulation. Supports -G0/-G1/-G2 styles. */

--- a/src/ragel/host-zig/rlparse.lm
+++ b/src/ragel/host-zig/rlparse.lm
@@ -1,0 +1,207 @@
+include 'ragel.lm'
+include 'rlreduce.lm'
+
+# Zig identifiers with optional '@' prefix for builtins.
+rl ident
+	/ '@'? ( alpha | '_' ) ( alpha | digit | '_' )* /
+
+rl number
+	/ digit ( digit | '_' )* /
+
+rl hex_number
+	/ '0x' [0-9a-fA-F_]+ /
+
+rl NL / '\n' /
+
+# Zig has line comments only, no block comments.
+rl line_comment
+	/ '//' [^\n]* NL /
+
+rl char_literal
+	/ "'" ([^'\\\n] | '\\' (any | NL)) "'" /
+
+rl string_literal
+	/ '"' ([^"\\\n] | '\\' (any | NL))* '"' /
+
+# Multiline strings with '\\'; treat as atomic to skip brace scanning.
+rl ml_string
+	/ '\\\\' [^\n]* NL /
+
+# Quoted identifier @"...".
+rl quoted_ident
+	/ '@"' ([^"\\\n] | '\\' (any | NL))* '"' /
+
+namespace inline
+	lex
+		literal `fpc `fc  `fcurs `ftargs
+			`fentry `fhold `fexec `fgoto `fnext
+			`fcall `fret `fbreak `fncall `fnret `fnbreak
+
+		token quoted_ident /quoted_ident/
+		token ident /ident/
+		token number /number/
+		token hex_number /hex_number/
+
+		token comment
+			/ line_comment /
+
+		token string
+			/ char_literal | string_literal | ml_string /
+
+		token whitespace
+			/ ( [ \t] | NL )+ /
+
+		literal
+			`{ `} `:: `* `, `( `) `;
+
+		token var_ref
+			/ "$" [a-zA-Z_][a-zA-Z_0-9]* /
+			{
+				if GblActionParams
+				{
+					input->push( make_token(
+							typeid<var_ref>, input->pull( match_length ) ) )
+				}
+				else
+				{
+					# Pull only one char to preserve keywords.
+					input->push( make_token(
+							typeid<c_any>, input->pull( 1 ) ) )
+				}
+			}
+
+		token c_any
+			/ any /
+	end
+
+end
+
+namespace host
+	lex
+		literal `%%{
+
+		token close_inc /'}--%%'/
+		{
+			input->push( make_token( typeid<close_inc>, input->pull( match_length ) ) )
+			restoreGlobals()
+		}
+
+		token close_imp /'}++%%'/
+		{
+			input->push( make_token( typeid<close_imp>, input->pull( match_length ) ) )
+			restoreGlobals()
+		}
+
+		token slr / '%%' [^{] [^\n]* '\n' /
+		{
+			# Convert single-line Ragel block to multi-line format.
+			input->pull( 2 )
+			R: str = input->pull( match_length - 3 )
+			input->push( "}%%" )
+			input->push( R )
+			input->push( "%%{" )
+		}
+
+		rl NL / '\n' /
+
+		literal `define `=
+
+		token quoted_ident /quoted_ident/
+		token ident /ident/
+		token number /number/
+		token hex_number /hex_number/
+
+		token comment
+			/ line_comment /
+
+		token string
+			/ char_literal | string_literal | ml_string /
+
+		token whitespace
+			/ ( [ \t] | NL )+ /
+
+		token c_any / any /
+	end
+
+	def tok
+		[`define whitespace ident whitespace? number]  :ImportDefNum
+	|	[`define whitespace ident whitespace? string]  :ImportDefStr
+	|	[ident whitespace? `= whitespace? number]      :ImportAssignNum
+	|	[ident whitespace? `= whitespace? string]      :ImportAssignStr
+	|	[`define]              :Def
+	|	[`=]                   :Eq
+	|	[quoted_ident] :QuotedIdent
+	|	[ident] :Ident
+	|	[number] :Number
+	|	[hex_number] :HexNumber
+	|	[comment] :Comment
+	|	[string] :String
+	|	[whitespace] :Whitespace
+	|	[c_any] :Any
+end
+
+reduction TopLevel
+
+	host::tok  :ImportDefNum
+	{
+		if ( isImport )
+		{
+			Literal *lit = new Literal( @number,
+					false /* $number->neg */, $number->data,
+					$number->length, Literal::Number );
+
+			string name( $ident->data, $ident->length );
+			import( @ident, name, lit );
+		}
+	}
+	host::tok  :ImportDefStr
+	{
+		if ( isImport )
+		{
+			Literal *lit = new Literal( @string, false,
+					$string->data, $string->length, Literal::LitString );
+			string name( $ident->data, $ident->length );
+			import( @ident, name, lit );
+		}
+	}
+	host::tok  :ImportAssignNum
+	{
+		if ( isImport )
+		{
+			Literal *lit = new Literal( @number,
+					false /*$number->neg */, $number->data,
+					$number->length, Literal::Number );
+			string name( $ident->data, $ident->length );
+			import( @ident, name, lit );
+		}
+	}
+	host::tok  :ImportAssignStr
+	{
+		if ( isImport )
+		{
+			Literal *lit = new Literal( @string, false,
+					$string->data, $string->length, Literal::LitString );
+
+			string name( $ident->data, $ident->length );
+			import( @ident, name, lit );
+		}
+	}
+
+end
+
+export RagelError: str
+
+# File name. The open is expected to succeed. It is tested before the colm
+# program is called.
+A: list_el<str> = argv->pop_head_el()
+GblFileName = A->value
+
+# Remaining items are include paths.
+while ( argv->length > 0 ) {
+	A = argv->pop_head_el()
+	GblIncludePaths->push_tail_el( A )
+}
+
+Stream: stream = open( GblFileName, "r" )
+reduce TopLevel start[ Stream ]
+RagelError = error

--- a/src/ragel/inputdata.cc
+++ b/src/ragel/inputdata.cc
@@ -687,6 +687,7 @@ void InputData::usage()
 "   ragel-ruby           Ruby        -T0 -T1 -F0 -F1\n"
 "   ragel-ocaml          OCaml       -T0 -T1 -F0 -F1\n"
 "   ragel-rust           Rust        -T0 -T1 -F0 -F1\n"
+"   ragel-zig            Zig         All code styles supported\n"
 "   ragel-julia          Julia       -T0 -T1 -F0 -F1\n"
 "   ragel-crack          Crack       -T0 -T1 -F0 -F1\n"
 "   ragel-js             JavaScript  -T0 -T1 -F0 -F1\n"

--- a/test/ragel.d/Makefile.am
+++ b/test/ragel.d/Makefile.am
@@ -33,7 +33,7 @@ EXTRA_DIST = \
 	gentests.sh trans.lm \
 	trans-asm.lm     trans-d.lm      trans-ocaml.lm \
 	trans-c.lm       trans-go.lm     trans-ruby.lm \
-	trans-crack.lm   trans-java.lm   trans-rust.lm \
+	trans-crack.lm   trans-java.lm   trans-rust.lm trans-zig.lm \
 	trans-csharp.lm  trans-julia.lm \
 	any1.rl args1.rl args2.rl argsinc.rl atoi1.rl atoi2.rl atoi3.rl \
 	atoi4.rl atoi5.rl awkemu.rl buffer.h builtin.rl call1.rl call2.rl \

--- a/test/ragel.d/Makefile.am
+++ b/test/ragel.d/Makefile.am
@@ -72,7 +72,7 @@ TRANS_DEPS = \
 	trans-d.lm trans-go.lm \
 	trans-java.lm trans-julia.lm \
 	trans-ocaml.lm trans-ruby.lm \
-	trans-rust.lm
+	trans-rust.lm trans-zig.lm
 
 trans_CPPFLAGS = $(COLM_xCPPFLAGS)
 trans_SOURCES = trans.c main.c

--- a/test/ragel.d/gentests.sh
+++ b/test/ragel.d/gentests.sh
@@ -27,6 +27,7 @@ export RAGEL_GO_BIN="@SUBJ_RAGEL_GO_BIN@"
 export RAGEL_OCAML_BIN="@SUBJ_RAGEL_OCAML_BIN@"
 export RAGEL_ASM_BIN="@SUBJ_RAGEL_ASM_BIN@"
 export RAGEL_RUST_BIN="@SUBJ_RAGEL_RUST_BIN@"
+export RAGEL_ZIG_BIN="@SUBJ_RAGEL_ZIG_BIN@"
 export RAGEL_CRACK_BIN="@SUBJ_RAGEL_CRACK_BIN@"
 export RAGEL_JULIA_BIN="@SUBJ_RAGEL_JULIA_BIN@"
 
@@ -44,7 +45,7 @@ wk=working
 test -d $wk || mkdir $wk
 echo $wk/* | xargs rm -Rf
 
-while getopts "gcnmleT:F:W:G:P:CDJRAZOUKY-:" opt; do
+while getopts "gcnmleT:F:W:G:P:CDJRAZOUKYB-:" opt; do
 	case $opt in
 		T|F|W|G|P)
 			genflags="$genflags -$opt$OPTARG"
@@ -61,7 +62,7 @@ while getopts "gcnmleT:F:W:G:P:CDJRAZOUKY-:" opt; do
 		g) 
 			allow_generated="true"
 		;;
-		C|D|J|R|A|Z|O|R|K|Y|U)
+		C|D|J|R|A|Z|O|R|K|Y|U|B)
 			langflags="$langflags -$opt"
 		;;
 		-)
@@ -86,7 +87,7 @@ while getopts "gcnmleT:F:W:G:P:CDJRAZOUKY-:" opt; do
 	esac
 done
 
-[ -z "$langflags" ]   && langflags="-C --asm -R -Y -O -U -J -Z -D -A -K"
+[ -z "$langflags" ]   && langflags="-C --asm -R -Y -O -U -J -Z -D -A -K -B"
 [ -z "$genflags" ]    && genflags="-T0 -T1 -F0 -F1 -W0 -W1 -G0 -G1 -G2 -n -m -e --string-tables"
 
 shift $((OPTIND - 1));
@@ -105,6 +106,7 @@ csharp_compiler="@CSHARP_BIN@"
 go_compiler="@GO_BIN@"
 ocaml_compiler="@OCAML_BIN@"
 rust_compiler="@RUST_BIN@"
+zig_compiler="@ZIG_BIN@"
 crack_interpreter="@CRACK_BIN@"
 julia_interpreter="@JULIA_BIN@"
 gnustep_config="@GNUSTEP_CONFIG@"
@@ -278,6 +280,16 @@ function lang_opts()
 			libs=""
 			prohibit_flags="-G0 -G1 -G2 --string-tables"
 		;;
+		zig)
+			lang_opt="-B"
+			code_suffix=zig
+			interpreted=false
+			compiler=$zig_compiler
+			host_ragel=$RAGEL_ZIG_BIN
+			flags="build-exe"
+			libs=""
+			prohibit_flags="--string-tables"
+		;;
 		crack)
 			lang_opt="-K"
 			code_suffix=crk
@@ -334,6 +346,7 @@ function run_test()
 	out_args=""
 	[ $lang != java ] && out_args="-o $binary";
 	[ $lang == csharp ] && out_args="-out:$binary";
+	[ $lang == zig ] && out_args="-femit-bin=$binary";
 
 	# Some langs are just interpreted.
 	if [ $interpreted != "true" ]; then
@@ -441,7 +454,7 @@ function run_translate()
 	cases=""
 
 	if [ $lang == indep ]; then
-		for lang in c cg cv asm d csharp go java ruby ocaml rust crack julia; do
+		for lang in c cg cv asm d csharp go java ruby ocaml rust crack julia zig; do
 			case $lang in 
 				c) lf="-C" ;;
 				cg) lf="-C" ;;
@@ -456,6 +469,7 @@ function run_translate()
 				rust) lf="-U" ;;
 				crack) lf="-K" ;;
 				julia) lf="-Y" ;;
+				zig) lf="-B" ;;
 			esac
 
 			echo "$prohibit_languages" | grep -q "\<$lang\>" && continue;

--- a/test/ragel.d/trans-zig.lm
+++ b/test/ragel.d/trans-zig.lm
@@ -1,0 +1,364 @@
+namespace trans_zig
+
+	int factor( Factor: indep::factor )
+	{
+		if match Factor [`first_token_char]
+		{
+			send Out "data\[@intCast(ts)\]"
+		}
+		else if match Factor [tk_ident `[ expr `]]
+		{
+			send Out
+				"[$Factor.tk_ident]\[@intCast( [expr(Factor.expr)] )\]
+		}
+		else if match Factor [tk_ident `( expr `)]
+		{
+			send Out
+				"[$Factor.tk_ident]( [expr(Factor.expr)] )
+		}
+		elsif match Factor [`< type `> `( expr `)]
+		{
+			send Out
+				"@as( [type(Factor.type)], @intCast( [expr(Factor.expr)] ) )
+		}
+		elsif match Factor [`( expr `)]
+		{
+			send Out
+				"( [expr(Factor.expr)] )
+		}
+		elsif match Factor ['true']
+		{
+			send Out 'true'
+		}
+		elsif match Factor ['false']
+		{
+			send Out 'false'
+		}
+		elsif match Factor [`buffer]
+		{
+			send Out
+				"buffer\[0..blen\]"
+		}
+		elsif match Factor [`blen]
+		{
+			send Out
+				"@as( i32, @intCast( blen ) )"
+		}
+		else
+		{
+			send Out [$Factor]
+		}
+	}
+
+	void type( Type: indep::type )
+	{
+		switch Type
+		case [`int]
+		{
+			send Out "i32"
+		}
+		case [`bool]
+		{
+			send Out "bool"
+		}
+		case [`char]
+		{
+			send Out "u8"
+		}
+		case [`ptr]
+		{
+			send Out "i32"
+		}
+		case [`byte]
+		{
+			send Out "u8"
+		}
+	}
+
+	void abs_expr( Expr: indep::abs_expr )
+	{
+		if ( Expr.Op ) {
+			# Zig spells the logical connectives 'and'/'or'.
+			Op: str = $Expr.Op
+			if ( Op == '&&' )
+				Op = 'and'
+			elsif ( Op == '||' )
+				Op = 'or'
+			send Out
+				"[abs_expr(Expr.E1)] [Op] [abs_expr( Expr.E2 )]"
+		}
+		else {
+			factor( Expr.factor )
+		}
+	}
+
+	void expr( Expr: indep::expr )
+	{
+		AbsExpr: indep::abs_expr = indep::abs_comparative( Expr.comparative )
+		abs_expr( AbsExpr )
+	}
+
+	void array_init( Size: int, Zero: str )
+	{
+		while ( Size > 1 ) {
+			send Out
+				"[Zero], "
+			Size = Size - 1
+		}
+
+		if ( Size > 0 ) {
+			send Out
+				"[Zero]"
+		}
+	}
+
+	int var_decl( VarDecl: indep::var_decl )
+	{
+		Zero: str = '0'
+		if match VarDecl.type [`bool]
+			Zero = 'false'
+
+		if VarDecl.opt_arr.expr {
+			send Out
+				"var [VarDecl.tk_ident]: "
+					"\[[expr( VarDecl.opt_arr.expr )]\][type( VarDecl.type )] = "
+					".{ [array_init( atoi($VarDecl.opt_arr.expr), Zero )] };
+		}
+		else {
+			send Out
+				"var [VarDecl.tk_ident]: [type( VarDecl.type )] = [Zero];
+		}
+	}
+
+	void opt_sub( OptSub: indep::opt_sub )
+	{
+		if ( OptSub.expr )
+			send Out "\[@intCast( [expr(OptSub.expr)] )\]"
+	}
+
+	int expr_stmt( ExprStmt: indep::expr_stmt )
+	{
+		if match ExprStmt [tk_ident opt_sub `= expr `;]
+		{
+			send Out
+				"[$ExprStmt.tk_ident opt_sub(ExprStmt.opt_sub)] = [expr(ExprStmt.expr)];
+		}
+		else if match ExprStmt [expr `;]
+		{
+			send Out
+				"[expr(ExprStmt.expr)];
+		}
+	}
+
+	int if_stmt( IfStmt: indep::if_stmt )
+	{
+		send Out
+			"if ( [expr( IfStmt.expr )] )
+			"{
+			"	[stmt_list( IfStmt._repeat_stmt )]
+			"}
+
+		if ( IfStmt.opt_else._repeat_stmt ) {
+			send Out
+				"else {
+				"	[stmt_list( IfStmt.opt_else._repeat_stmt )]
+				"}
+		}
+	}
+
+	int print_stmt( Stmt: indep::print_stmt )
+	{
+		switch Stmt
+		case [`print_int expr `;] {
+			send Out
+				"std.debug.print( \"{d}\", .{ [expr(Stmt.expr)] } );
+		}
+		case [`print_buf `;]
+		{
+			send Out
+				"std.debug.print( \"{s}\", .{ buffer\[0..blen\] } );
+		}
+		case [`print_str expr `;]
+		{
+			send Out
+				"std.debug.print( \"{s}\", .{ [expr( Stmt.expr )] } );
+		}
+		case [`print_token `;]
+		{
+			send Out
+				"std.debug.print( \"{s}\", .{ data\[@intCast(ts)..@intCast(te)\] } );
+		}
+	}
+
+	void buf_stmt( BufStmt: indep::buf_stmt )
+	{
+		switch BufStmt
+		case [`buf_clear `( `) `;] {
+			send Out
+				"	blen = 0;
+		}
+		case [`buf_append `( `) `;] {
+			send Out
+				"	buffer\[blen\] = fc; blen += 1;
+		}
+	}
+
+
+	int ragel_stmt( Stmt: indep::ragel_stmt )
+	{
+		send Out
+			[$Stmt]
+	}
+
+	int stmt( Stmt: indep::stmt )
+	{
+		switch Stmt
+		case [var_decl]
+			var_decl( Stmt.var_decl )
+		case [expr_stmt]
+			expr_stmt( Stmt.expr_stmt )
+		case [if_stmt]
+			if_stmt( Stmt.if_stmt )
+		case [print_stmt]
+			print_stmt( Stmt.print_stmt )
+		case [buf_stmt]
+			buf_stmt( Stmt.buf_stmt )
+		case [ragel_stmt]
+			ragel_stmt( Stmt.ragel_stmt )
+	}
+
+	void stmt_list( StmtList: indep::stmt* )
+	{
+		for Stmt: indep::stmt in repeat( StmtList )
+			stmt( Stmt )
+	}
+
+	int action_block( ActionBlock: indep::action_block )
+	{
+		Out = new parser<out_code::lines>()
+		if match ActionBlock [`{ stmt* `}] {
+			send Out
+				"{[stmt_list( ActionBlock._repeat_stmt )]}
+		}
+		else if match ActionBlock [`{ expr `}] {
+			send Out
+				"{[expr( ActionBlock.expr )]}
+		}
+		send Out [] eos
+	}
+
+	void zig( Output: stream )
+	{
+		# Translate action blocks.
+		Section: indep::section = RagelTree.section
+		for Action: ragel::action_block in Section {
+			# Reparse as lang-independent code.
+			parse IndepActionBlock: indep::action_block[$Action]
+			if ( !IndepActionBlock ) {
+				print( error, '\n', Action )
+				exit(1)
+			}
+
+			action_block( IndepActionBlock )
+
+			# Reparse back to ragel action block.
+			Action = parse ragel::action_block[$Out->tree]
+			if ( !Action ) {
+				print( error, '\n' )
+				exit(1)
+			}
+		}
+
+		send Output
+			"//
+			"// @LANG: zig
+			"// @GENERATED: true
+
+		if ProhibitGenflags {
+			send Output
+				"// @PROHIBIT_GENFLAGS:[ProhibitGenflags]
+		}
+
+		send Output
+			"//
+			"
+			"const std = @import(\"std\");
+			"
+
+		# Globals declared by the test go at container scope, where Zig does
+		# not complain about them being unused or never mutated.
+		Init: indep::stmt* = RagelTree.Init
+		for Stmt: indep::stmt in Init {
+			if match Stmt [Decl: var_decl] {
+				Out = new parser<out_code::lines>()
+				var_decl( Decl )
+				send Out [] eos
+				send Output [Out->tree]
+			}
+		}
+
+		send Output
+			"
+			"[Section]
+			"
+			"%% write data;
+			"
+			"fn m( s: \[\]const u8 ) void
+			"{
+			"	const data = s;
+			"	var p: i32 = 0;
+			"	var pe: i32 = @intCast( s.len );
+			"	var eof: i32 = @intCast( s.len );
+			"	var cs: i32 = 0;
+			"	var buffer: \[1024\]u8 = undefined;
+			"	var blen: usize = 0;
+			"	var nfa_len: i32 = 0;
+			"	var nfa_count: i32 = 0;
+			"	var nfa_bp_state: \[20\]i32 = .{ 0 } ** 20;
+			"	var nfa_bp_p: \[20\]i32 = .{ 0 } ** 20;
+			"
+			"	// Zig rejects unused locals, and a 'var' that is never
+			"	// mutated. Taking the address counts as both and does not
+			"	// survive optimisation.
+			"	_ = &p; _ = &pe; _ = &eof; _ = &cs;
+			"	_ = &buffer; _ = &blen;
+			"	_ = &nfa_len; _ = &nfa_count; _ = &nfa_bp_state; _ = &nfa_bp_p;
+
+		for Stmt: indep::stmt in Init {
+			if match Stmt [ExprStmt: expr_stmt] {
+				Out = new parser<out_code::lines>()
+				expr_stmt( ExprStmt )
+				send Out [] eos
+				send Output [Out->tree]
+			}
+		}
+
+		send Output
+			"
+			"	%% write init;
+			"	%% write exec;
+			"
+			"	if ( cs >= [MachineName.mn_word]_first_final ) {
+			"		std.debug.print( \"ACCEPT\\n\", .{} );
+			"	}
+			"	else {
+			"		std.debug.print( \"FAIL\\n\", .{} );
+			"	}
+			"}
+
+		send Output
+			~
+			~pub fn main() void
+			~{
+
+		for InputString: indep::input_string in RagelTree {
+			send Output
+				"	m( [^InputString] );
+		}
+
+		send Output
+			~}
+			~
+	}
+
+end

--- a/test/ragel.d/trans-zig.lm
+++ b/test/ragel.d/trans-zig.lm
@@ -1,364 +1,374 @@
 namespace trans_zig
 
-	int factor( Factor: indep::factor )
+int factor( Factor: indep::factor )
+{
+	if match Factor [`first_token_char]
 	{
-		if match Factor [`first_token_char]
-		{
-			send Out "data\[@intCast(ts)\]"
-		}
-		else if match Factor [tk_ident `[ expr `]]
-		{
-			send Out
-				"[$Factor.tk_ident]\[@intCast( [expr(Factor.expr)] )\]
-		}
-		else if match Factor [tk_ident `( expr `)]
-		{
-			send Out
-				"[$Factor.tk_ident]( [expr(Factor.expr)] )
-		}
-		elsif match Factor [`< type `> `( expr `)]
-		{
-			send Out
-				"@as( [type(Factor.type)], @intCast( [expr(Factor.expr)] ) )
-		}
-		elsif match Factor [`( expr `)]
-		{
-			send Out
-				"( [expr(Factor.expr)] )
-		}
-		elsif match Factor ['true']
-		{
-			send Out 'true'
-		}
-		elsif match Factor ['false']
-		{
-			send Out 'false'
-		}
-		elsif match Factor [`buffer]
-		{
-			send Out
-				"buffer\[0..blen\]"
-		}
-		elsif match Factor [`blen]
-		{
-			send Out
-				"@as( i32, @intCast( blen ) )"
-		}
-		else
-		{
-			send Out [$Factor]
-		}
+		send Out "data\[@intCast(ts)\]"
 	}
-
-	void type( Type: indep::type )
-	{
-		switch Type
-		case [`int]
-		{
-			send Out "i32"
-		}
-		case [`bool]
-		{
-			send Out "bool"
-		}
-		case [`char]
-		{
-			send Out "u8"
-		}
-		case [`ptr]
-		{
-			send Out "i32"
-		}
-		case [`byte]
-		{
-			send Out "u8"
-		}
-	}
-
-	void abs_expr( Expr: indep::abs_expr )
-	{
-		if ( Expr.Op ) {
-			# Zig spells the logical connectives 'and'/'or'.
-			Op: str = $Expr.Op
-			if ( Op == '&&' )
-				Op = 'and'
-			elsif ( Op == '||' )
-				Op = 'or'
-			send Out
-				"[abs_expr(Expr.E1)] [Op] [abs_expr( Expr.E2 )]"
-		}
-		else {
-			factor( Expr.factor )
-		}
-	}
-
-	void expr( Expr: indep::expr )
-	{
-		AbsExpr: indep::abs_expr = indep::abs_comparative( Expr.comparative )
-		abs_expr( AbsExpr )
-	}
-
-	void array_init( Size: int, Zero: str )
-	{
-		while ( Size > 1 ) {
-			send Out
-				"[Zero], "
-			Size = Size - 1
-		}
-
-		if ( Size > 0 ) {
-			send Out
-				"[Zero]"
-		}
-	}
-
-	int var_decl( VarDecl: indep::var_decl )
-	{
-		Zero: str = '0'
-		if match VarDecl.type [`bool]
-			Zero = 'false'
-
-		if VarDecl.opt_arr.expr {
-			send Out
-				"var [VarDecl.tk_ident]: "
-					"\[[expr( VarDecl.opt_arr.expr )]\][type( VarDecl.type )] = "
-					".{ [array_init( atoi($VarDecl.opt_arr.expr), Zero )] };
-		}
-		else {
-			send Out
-				"var [VarDecl.tk_ident]: [type( VarDecl.type )] = [Zero];
-		}
-	}
-
-	void opt_sub( OptSub: indep::opt_sub )
-	{
-		if ( OptSub.expr )
-			send Out "\[@intCast( [expr(OptSub.expr)] )\]"
-	}
-
-	int expr_stmt( ExprStmt: indep::expr_stmt )
-	{
-		if match ExprStmt [tk_ident opt_sub `= expr `;]
-		{
-			send Out
-				"[$ExprStmt.tk_ident opt_sub(ExprStmt.opt_sub)] = [expr(ExprStmt.expr)];
-		}
-		else if match ExprStmt [expr `;]
-		{
-			send Out
-				"[expr(ExprStmt.expr)];
-		}
-	}
-
-	int if_stmt( IfStmt: indep::if_stmt )
+	else if match Factor [tk_ident `[ expr `]]
 	{
 		send Out
-			"if ( [expr( IfStmt.expr )] )
-			"{
-			"	[stmt_list( IfStmt._repeat_stmt )]
-			"}
-
-		if ( IfStmt.opt_else._repeat_stmt ) {
-			send Out
-				"else {
-				"	[stmt_list( IfStmt.opt_else._repeat_stmt )]
-				"}
-		}
+			"[$Factor.tk_ident]\[@intCast( [expr(Factor.expr)] )\]
 	}
-
-	int print_stmt( Stmt: indep::print_stmt )
-	{
-		switch Stmt
-		case [`print_int expr `;] {
-			send Out
-				"std.debug.print( \"{d}\", .{ [expr(Stmt.expr)] } );
-		}
-		case [`print_buf `;]
-		{
-			send Out
-				"std.debug.print( \"{s}\", .{ buffer\[0..blen\] } );
-		}
-		case [`print_str expr `;]
-		{
-			send Out
-				"std.debug.print( \"{s}\", .{ [expr( Stmt.expr )] } );
-		}
-		case [`print_token `;]
-		{
-			send Out
-				"std.debug.print( \"{s}\", .{ data\[@intCast(ts)..@intCast(te)\] } );
-		}
-	}
-
-	void buf_stmt( BufStmt: indep::buf_stmt )
-	{
-		switch BufStmt
-		case [`buf_clear `( `) `;] {
-			send Out
-				"	blen = 0;
-		}
-		case [`buf_append `( `) `;] {
-			send Out
-				"	buffer\[blen\] = fc; blen += 1;
-		}
-	}
-
-
-	int ragel_stmt( Stmt: indep::ragel_stmt )
+	else if match Factor [tk_ident `( expr `)]
 	{
 		send Out
-			[$Stmt]
+			"[$Factor.tk_ident]( [expr(Factor.expr)] )
+	}
+	elsif match Factor [`< type `> `( expr `)]
+	{
+		send Out
+			"@as( [type(Factor.type)], @intCast( [expr(Factor.expr)] ) )
+	}
+	elsif match Factor [`( expr `)]
+	{
+		send Out
+			"( [expr(Factor.expr)] )
+	}
+	elsif match Factor ['true']
+	{
+		send Out 'true'
+	}
+	elsif match Factor ['false']
+	{
+		send Out 'false'
+	}
+	elsif match Factor [`buffer]
+	{
+		send Out
+			"buffer\[0..blen\]"
+	}
+	elsif match Factor [`blen]
+	{
+		send Out
+			"@as( i32, @intCast( blen ) )"
+	}
+	else
+	{
+		send Out [$Factor]
+	}
+}
+
+void type( Type: indep::type )
+{
+	switch Type
+	case [`int]
+	{
+		send Out "i32"
+	}
+	case [`bool]
+	{
+		send Out "bool"
+	}
+	case [`char]
+	{
+		send Out "u8"
+	}
+	case [`ptr]
+	{
+		send Out "i32"
+	}
+	case [`byte]
+	{
+		send Out "u8"
+	}
+}
+
+void abs_expr( Expr: indep::abs_expr )
+{
+	if ( Expr.Op ) {
+		# Zig uses 'and'/'or' instead of '&&'/'||'.
+		Op: str = $Expr.Op
+		if ( Op == '&&' )
+			Op = 'and'
+		elsif ( Op == '||' )
+			Op = 'or'
+		send Out
+			"[abs_expr(Expr.E1)] [Op] [abs_expr( Expr.E2 )]"
+	}
+	else {
+		factor( Expr.factor )
+	}
+}
+
+void expr( Expr: indep::expr )
+{
+	AbsExpr: indep::abs_expr = indep::abs_comparative( Expr.comparative )
+	abs_expr( AbsExpr )
+}
+
+void array_init( Size: int, Zero: str )
+{
+	while ( Size > 1 ) {
+		send Out
+			"[Zero], "
+		Size = Size - 1
 	}
 
-	int stmt( Stmt: indep::stmt )
-	{
-		switch Stmt
-		case [var_decl]
-			var_decl( Stmt.var_decl )
-		case [expr_stmt]
-			expr_stmt( Stmt.expr_stmt )
-		case [if_stmt]
-			if_stmt( Stmt.if_stmt )
-		case [print_stmt]
-			print_stmt( Stmt.print_stmt )
-		case [buf_stmt]
-			buf_stmt( Stmt.buf_stmt )
-		case [ragel_stmt]
-			ragel_stmt( Stmt.ragel_stmt )
+	if ( Size > 0 ) {
+		send Out
+			"[Zero]"
 	}
+}
 
-	void stmt_list( StmtList: indep::stmt* )
-	{
-		for Stmt: indep::stmt in repeat( StmtList )
-			stmt( Stmt )
+int var_decl( VarDecl: indep::var_decl )
+{
+	Zero: str = '0'
+	if match VarDecl.type [`bool]
+		Zero = 'false'
+
+	if VarDecl.opt_arr.expr {
+		send Out
+			"var [VarDecl.tk_ident]: "
+				"\[[expr( VarDecl.opt_arr.expr )]\][type( VarDecl.type )] = "
+				".{ [array_init( atoi($VarDecl.opt_arr.expr), Zero )] };
 	}
-
-	int action_block( ActionBlock: indep::action_block )
-	{
-		Out = new parser<out_code::lines>()
-		if match ActionBlock [`{ stmt* `}] {
-			send Out
-				"{[stmt_list( ActionBlock._repeat_stmt )]}
-		}
-		else if match ActionBlock [`{ expr `}] {
-			send Out
-				"{[expr( ActionBlock.expr )]}
-		}
-		send Out [] eos
+	else {
+		send Out
+			"var [VarDecl.tk_ident]: [type( VarDecl.type )] = [Zero];
 	}
+}
 
-	void zig( Output: stream )
+void opt_sub( OptSub: indep::opt_sub )
+{
+	if ( OptSub.expr )
+		send Out "\[@intCast( [expr(OptSub.expr)] )\]"
+}
+
+int expr_stmt( ExprStmt: indep::expr_stmt )
+{
+	if match ExprStmt [tk_ident opt_sub `= expr `;]
 	{
-		# Translate action blocks.
-		Section: indep::section = RagelTree.section
-		for Action: ragel::action_block in Section {
-			# Reparse as lang-independent code.
-			parse IndepActionBlock: indep::action_block[$Action]
-			if ( !IndepActionBlock ) {
-				print( error, '\n', Action )
-				exit(1)
-			}
+		send Out
+			"[$ExprStmt.tk_ident opt_sub(ExprStmt.opt_sub)] = [expr(ExprStmt.expr)];
+	}
+	else if match ExprStmt [expr `;]
+	{
+		send Out
+			"[expr(ExprStmt.expr)];
+	}
+}
 
-			action_block( IndepActionBlock )
+int if_stmt( IfStmt: indep::if_stmt )
+{
+	send Out
+		"if ( [expr( IfStmt.expr )] )
+		"{
+		"	[stmt_list( IfStmt._repeat_stmt )]
+		"}
 
-			# Reparse back to ragel action block.
-			Action = parse ragel::action_block[$Out->tree]
-			if ( !Action ) {
-				print( error, '\n' )
-				exit(1)
-			}
-		}
-
-		send Output
-			"//
-			"// @LANG: zig
-			"// @GENERATED: true
-
-		if ProhibitGenflags {
-			send Output
-				"// @PROHIBIT_GENFLAGS:[ProhibitGenflags]
-		}
-
-		send Output
-			"//
-			"
-			"const std = @import(\"std\");
-			"
-
-		# Globals declared by the test go at container scope, where Zig does
-		# not complain about them being unused or never mutated.
-		Init: indep::stmt* = RagelTree.Init
-		for Stmt: indep::stmt in Init {
-			if match Stmt [Decl: var_decl] {
-				Out = new parser<out_code::lines>()
-				var_decl( Decl )
-				send Out [] eos
-				send Output [Out->tree]
-			}
-		}
-
-		send Output
-			"
-			"[Section]
-			"
-			"%% write data;
-			"
-			"fn m( s: \[\]const u8 ) void
-			"{
-			"	const data = s;
-			"	var p: i32 = 0;
-			"	var pe: i32 = @intCast( s.len );
-			"	var eof: i32 = @intCast( s.len );
-			"	var cs: i32 = 0;
-			"	var buffer: \[1024\]u8 = undefined;
-			"	var blen: usize = 0;
-			"	var nfa_len: i32 = 0;
-			"	var nfa_count: i32 = 0;
-			"	var nfa_bp_state: \[20\]i32 = .{ 0 } ** 20;
-			"	var nfa_bp_p: \[20\]i32 = .{ 0 } ** 20;
-			"
-			"	// Zig rejects unused locals, and a 'var' that is never
-			"	// mutated. Taking the address counts as both and does not
-			"	// survive optimisation.
-			"	_ = &p; _ = &pe; _ = &eof; _ = &cs;
-			"	_ = &buffer; _ = &blen;
-			"	_ = &nfa_len; _ = &nfa_count; _ = &nfa_bp_state; _ = &nfa_bp_p;
-
-		for Stmt: indep::stmt in Init {
-			if match Stmt [ExprStmt: expr_stmt] {
-				Out = new parser<out_code::lines>()
-				expr_stmt( ExprStmt )
-				send Out [] eos
-				send Output [Out->tree]
-			}
-		}
-
-		send Output
-			"
-			"	%% write init;
-			"	%% write exec;
-			"
-			"	if ( cs >= [MachineName.mn_word]_first_final ) {
-			"		std.debug.print( \"ACCEPT\\n\", .{} );
-			"	}
-			"	else {
-			"		std.debug.print( \"FAIL\\n\", .{} );
-			"	}
+	if ( IfStmt.opt_else._repeat_stmt ) {
+		send Out
+			"else {
+			"	[stmt_list( IfStmt.opt_else._repeat_stmt )]
 			"}
+	}
+}
 
-		send Output
-			~
-			~pub fn main() void
-			~{
+int print_stmt( Stmt: indep::print_stmt )
+{
+	switch Stmt
+	case [`print_int expr `;] {
+		send Out
+			"_out( \"{d}\", .{ [expr(Stmt.expr)] } );
+	}
+	case [`print_buf `;]
+	{
+		send Out
+			"_out( \"{s}\", .{ buffer\[0..blen\] } );
+	}
+	case [`print_str expr `;]
+	{
+		send Out
+			"_out( \"{s}\", .{ [expr( Stmt.expr )] } );
+	}
+	case [`print_token `;]
+	{
+		send Out
+			"_out( \"{s}\", .{ data\[@intCast(ts)..@intCast(te)\] } );
+	}
+}
 
-		for InputString: indep::input_string in RagelTree {
-			send Output
-				"	m( [^InputString] );
+void buf_stmt( BufStmt: indep::buf_stmt )
+{
+	switch BufStmt
+	case [`buf_clear `( `) `;] {
+		send Out
+			"	blen = 0;
+	}
+	case [`buf_append `( `) `;] {
+		send Out
+			"	buffer\[blen\] = fc; blen += 1;
+	}
+}
+
+
+int ragel_stmt( Stmt: indep::ragel_stmt )
+{
+	send Out
+		[$Stmt]
+}
+
+int stmt( Stmt: indep::stmt )
+{
+	switch Stmt
+	case [var_decl]
+		var_decl( Stmt.var_decl )
+	case [expr_stmt]
+		expr_stmt( Stmt.expr_stmt )
+	case [if_stmt]
+		if_stmt( Stmt.if_stmt )
+	case [print_stmt]
+		print_stmt( Stmt.print_stmt )
+	case [buf_stmt]
+		buf_stmt( Stmt.buf_stmt )
+	case [ragel_stmt]
+		ragel_stmt( Stmt.ragel_stmt )
+}
+
+void stmt_list( StmtList: indep::stmt* )
+{
+	for Stmt: indep::stmt in repeat( StmtList )
+		stmt( Stmt )
+}
+
+int action_block( ActionBlock: indep::action_block )
+{
+	Out = new parser<out_code::lines>()
+	if match ActionBlock [`{ stmt* `}] {
+		send Out
+			"{[stmt_list( ActionBlock._repeat_stmt )]}
+	}
+	else if match ActionBlock [`{ expr `}] {
+		send Out
+			"{[expr( ActionBlock.expr )]}
+	}
+	send Out [] eos
+}
+
+void zig( Output: stream )
+{
+	# Translate action blocks.
+	Section: indep::section = RagelTree.section
+	for Action: ragel::action_block in Section {
+		# Reparse as lang-independent code.
+		parse IndepActionBlock: indep::action_block[$Action]
+		if ( !IndepActionBlock ) {
+			print( error, '\n', Action )
+			exit(1)
 		}
 
-		send Output
-			~}
-			~
+		action_block( IndepActionBlock )
+
+		# Reparse back to ragel action block.
+		Action = parse ragel::action_block[$Out->tree]
+		if ( !Action ) {
+			print( error, '\n' )
+			exit(1)
+		}
 	}
+
+	send Output
+		"//
+		"// @LANG: zig
+		"// @GENERATED: true
+
+	if ProhibitGenflags {
+		send Output
+			"// @PROHIBIT_GENFLAGS:[ProhibitGenflags]
+	}
+
+	send Output
+		"//
+		"
+		"const std = @import(\"std\");
+		"
+		"// The test harness diffs stdout; std.debug.print is stderr only.
+		"var _thr: std.Io.Threaded = .init_single_threaded;
+		"var _obuf: \[4096\]u8 = undefined;
+		"var _ow: ?std.Io.File.Writer = null;
+		"
+		"fn _out( comptime fmt: \[\]const u8, args: anytype ) void
+		"{
+		"	if ( _ow == null )
+		"		_ow = std.Io.File.stdout().writer( _thr.io(), &_obuf );
+		"	_ow.?.interface.print( fmt, args ) catch {};
+		"	_ow.?.interface.flush() catch {};
+		"}
+		"
+
+	# Globals declared by the test go at container scope, where Zig does
+	# not complain about them being unused or never mutated.
+	Init: indep::stmt* = RagelTree.Init
+	for Stmt: indep::stmt in Init {
+		if match Stmt [Decl: var_decl] {
+			Out = new parser<out_code::lines>()
+			var_decl( Decl )
+			send Out [] eos
+			send Output [Out->tree]
+		}
+	}
+
+	send Output
+		"
+		"[Section]
+		"
+		"%% write data;
+		"
+		"fn m( s: \[\]const u8 ) void
+		"{
+		"	const data = s;
+		"	var p: i32 = 0;
+		"	var pe: i32 = @intCast( s.len );
+		"	var eof: i32 = @intCast( s.len );
+		"	var cs: i32 = 0;
+		"	var buffer: \[1024\]u8 = undefined;
+		"	var blen: usize = 0;
+		"	var nfa_len: i32 = 0;
+		"	var nfa_count: i32 = 0;
+		"	var nfa_bp_state: \[20\]i32 = .{ 0 } ** 20;
+		"	var nfa_bp_p: \[20\]i32 = .{ 0 } ** 20;
+		"
+		"	_ = &p; _ = &pe; _ = &eof; _ = &cs;
+		"	_ = &buffer; _ = &blen;
+		"	_ = &nfa_len; _ = &nfa_count; _ = &nfa_bp_state; _ = &nfa_bp_p;
+
+	for Stmt: indep::stmt in Init {
+		if match Stmt [ExprStmt: expr_stmt] {
+			Out = new parser<out_code::lines>()
+			expr_stmt( ExprStmt )
+			send Out [] eos
+			send Output [Out->tree]
+		}
+	}
+
+	send Output
+		"
+		"	%% write init;
+		"	%% write exec;
+		"
+		"	if ( cs >= [MachineName.mn_word]_first_final ) {
+		"		_out( \"ACCEPT\\n\", .{} );
+		"	}
+		"	else {
+		"		_out( \"FAIL\\n\", .{} );
+		"	}
+		"}
+
+	send Output
+		~
+		~pub fn main() void
+		~{
+
+	for InputString: indep::input_string in RagelTree {
+		send Output
+			"	m( [^InputString] );
+	}
+
+	send Output
+		~}
+		~
+}
 
 end

--- a/test/ragel.d/trans.lm
+++ b/test/ragel.d/trans.lm
@@ -455,6 +455,7 @@ include 'trans-ocaml.lm'
 include 'trans-rust.lm'
 include 'trans-julia.lm'
 include 'trans-crack.lm'
+include 'trans-zig.lm'
 
 str argvPop()
 {
@@ -520,6 +521,8 @@ elsif ( Lang == 'julia' )
 	trans_julia::julia( Output )
 elsif ( Lang == 'crack' )
 	trans_crack::crack( Output )
+elsif ( Lang == 'zig' )
+	trans_zig::zig( Output )
 else {
 	print( 'trans: unrecognized language: ', Lang, '\n' )
 }

--- a/test/rlparse.d/common.cc
+++ b/test/rlparse.d/common.cc
@@ -119,6 +119,18 @@ HostType hostTypesJulia[] =
 	{ "u8",    0,  "byte",      true,   true,  false,  0, UCHAR_MAX,  0, 0, 4 },
 };
 
+HostType hostTypesZig[] =
+{
+	{ "u8",  0, "uint8",  false, true, false, 0, 0,                  U8BIT_MIN,  U8BIT_MAX,  1 },
+	{ "i8",  0, "int8",   true,  true, false, S8BIT_MIN,  S8BIT_MAX,  0, 0,                  1 },
+	{ "u16", 0, "uint16", false, true, false, 0, 0,                  U16BIT_MIN, U16BIT_MAX, 2 },
+	{ "i16", 0, "int16",  true,  true, false, S16BIT_MIN, S16BIT_MAX, 0, 0,                  2 },
+	{ "u32", 0, "uint32", false, true, false, 0, 0,                  U32BIT_MIN, U32BIT_MAX, 4 },
+	{ "i32", 0, "int32",  true,  true, false, S32BIT_MIN, S32BIT_MAX, 0, 0,                  4 },
+	{ "u64", 0, "uint64", false, true, false, 0, 0,                  U64BIT_MIN, U64BIT_MAX, 8 },
+	{ "i64", 0, "int64",  true,  true, false, S64BIT_MIN, S64BIT_MAX, 0, 0,                  8 },
+};
+
 HostType hostTypesJS[] =
 {
 	{ "s8",     0, "int8",    true,   true,  false,  CHAR_MIN,  CHAR_MAX,   0, 0,          1 },
@@ -251,6 +263,17 @@ const HostLang hostLangJulia = {
 	"julia"
 };
 
+const HostLang hostLangZig = {
+	"Zig",
+	"-B",
+	HostLang::Zig,
+	hostTypesZig, 8,
+	hostTypesZig+0,
+	false,
+	true,
+	"zig"
+};
+
 const HostLang hostLangJS = {
 	"JavaScript",
 	"-P",
@@ -274,6 +297,7 @@ const HostLang *hostLangs[] = {
 	&hostLangRust,
 	&hostLangCrack,
 	&hostLangJulia,
+	&hostLangZig,
 	&hostLangJS,
 };
 

--- a/test/rlparse.d/common.h
+++ b/test/rlparse.d/common.h
@@ -214,6 +214,7 @@ struct HostLang
 		Asm,
 		Rust,
 		Julia,
+		Zig,
 		JS
 	};
 
@@ -239,6 +240,7 @@ extern const HostLang hostLangCrack;
 extern const HostLang hostLangAsm;
 extern const HostLang hostLangRust;
 extern const HostLang hostLangJulia;
+extern const HostLang hostLangZig;
 extern const HostLang hostLangJS;
 
 extern const HostLang *hostLangs[];

--- a/test/rlparse.d/inputdata.cc
+++ b/test/rlparse.d/inputdata.cc
@@ -164,6 +164,12 @@ void InputData::juliaDefaultFileName( const char *inputFile )
 		outputFileName = fileNameFromStem( inputFile, ".jl" );
 }
 
+void InputData::zigDefaultFileName( const char *inputFile )
+{
+	if ( outputFileName == 0 )
+		outputFileName = fileNameFromStem( inputFile, ".zig" );
+}
+
 void InputData::jsDefaultFileName( const char *inputFile )
 {
 	/* If the output format is code and no output file name is given, then
@@ -205,6 +211,9 @@ void InputData::makeDefaultFileName()
 			break;
 		case HostLang::Julia:
 			juliaDefaultFileName( inputFileName );
+			break;
+		case HostLang::Zig:
+			zigDefaultFileName( inputFileName );
 			break;
 		case HostLang::JS:
 			jsDefaultFileName( inputFileName );

--- a/test/rlparse.d/inputdata.h
+++ b/test/rlparse.d/inputdata.h
@@ -331,6 +331,7 @@ struct InputData
 	void asmDefaultFileName( const char *inputFile );
 	void rustDefaultFileName( const char *inputFile );
 	void juliaDefaultFileName( const char *inputFile );
+	void zigDefaultFileName( const char *inputFile );
 	void jsDefaultFileName( const char *inputFile );
 
 	void writeOutput( InputItem *ii );

--- a/test/rlparse.d/main.cc
+++ b/test/rlparse.d/main.cc
@@ -109,6 +109,7 @@ void InputData::usage()
 "   -O                   OCaml       -T0 -T1 -F0 -F1\n"
 "   -U                   Rust        -T0 -T1 -F0 -F1\n"
 "   -Y                   Julia       -T0 -T1 -F0 -F1\n"
+"   -B                   Zig         -T0 -T1 -F0 -F1 -G0 -G1 -G2\n"
 "   -K                   Crack       -T0 -T1 -F0 -F1\n"
 "   -P                   JavaScript  -T0 -T1 -F0 -F1\n"
 "line directives:\n"
@@ -215,6 +216,7 @@ void InputData::showStyles()
 	case HostLang::C:
 	case HostLang::D:
 	case HostLang::Go:
+	case HostLang::Zig:
 		info() << "-T0 -T1 -F0 -F1 -G0 -G1 -G2" << endl;
 		break;
 	case HostLang::CSharp:
@@ -258,7 +260,7 @@ void escapeLineDirectivePath( std::ostream &out, char *path )
 
 void InputData::parseArgs( int argc, const char **argv )
 {
-	ParamCheck pc( "r:o:dnmleabjkS:M:I:CDEJZRAOKUYPvHh?-:sT:F:G:LpV", argc, argv );
+	ParamCheck pc( "r:o:dnmleabjkS:M:I:CDEJZRAOKUYBPvHh?-:sT:F:G:LpV", argc, argv );
 
 	bool showStylesOpt = false;
 
@@ -401,6 +403,9 @@ void InputData::parseArgs( int argc, const char **argv )
 				break;
 			case 'Y':
 				hostLang = &hostLangJulia;
+				break;
+			case 'B':
+				hostLang = &hostLangZig;
 				break;
 			case 'P':
 				hostLang = &hostLangJS;

--- a/test/trans.d/Makefile.am
+++ b/test/trans.d/Makefile.am
@@ -24,6 +24,7 @@ EXTRA_DIST = \
 	trans-ocaml.lm \
 	trans-ruby.lm \
 	trans-rust.lm \
+	trans-zig.lm \
 	$(CASES)
 
 trans.c: trans.lm $(TRANS_DEPS) $(COLM_BIN)
@@ -47,6 +48,7 @@ CASES =  \
 	case/any1.rl \
 	case/any1_ruby.rl \
 	case/any1_rust.rl \
+	case/any1_zig.rl \
 	case/atoi1_asm.rl \
 	case/atoi1_crack.rl \
 	case/atoi1_c.rl \
@@ -59,6 +61,7 @@ CASES =  \
 	case/atoi1.rl \
 	case/atoi1_ruby.rl \
 	case/atoi1_rust.rl \
+	case/atoi1_zig.rl \
 	case/atoi2_asm.rl \
 	case/atoi2_crack.rl \
 	case/atoi2_c.rl \
@@ -71,6 +74,7 @@ CASES =  \
 	case/atoi2.rl \
 	case/atoi2_ruby.rl \
 	case/atoi2_rust.rl \
+	case/atoi2_zig.rl \
 	case/call4_asm.rl \
 	case/call4_crack.rl \
 	case/call4_c.rl \
@@ -81,6 +85,7 @@ CASES =  \
 	case/call4_julia.rl \
 	case/call4.rl \
 	case/call4_rust.rl \
+	case/call4_zig.rl \
 	case/caseindep_asm.rl \
 	case/caseindep_crack.rl \
 	case/caseindep_c.rl \
@@ -93,6 +98,7 @@ CASES =  \
 	case/caseindep.rl \
 	case/caseindep_ruby.rl \
 	case/caseindep_rust.rl \
+	case/caseindep_zig.rl \
 	case/clang4_asm.rl \
 	case/clang4_crack.rl \
 	case/clang4_c.rl \
@@ -105,6 +111,7 @@ CASES =  \
 	case/clang4.rl \
 	case/clang4_ruby.rl \
 	case/clang4_rust.rl \
+	case/clang4_zig.rl \
 	case/cond1_asm.rl \
 	case/cond1_crack.rl \
 	case/cond1_c.rl \
@@ -117,6 +124,7 @@ CASES =  \
 	case/cond1.rl \
 	case/cond1_ruby.rl \
 	case/cond1_rust.rl \
+	case/cond1_zig.rl \
 	case/cond7_asm.rl \
 	case/cond7_crack.rl \
 	case/cond7_c.rl \
@@ -129,6 +137,7 @@ CASES =  \
 	case/cond7.rl \
 	case/cond7_ruby.rl \
 	case/cond7_rust.rl \
+	case/cond7_zig.rl \
 	case/cppscan6_asm.rl \
 	case/cppscan6_crack.rl \
 	case/cppscan6_c.rl \
@@ -141,6 +150,7 @@ CASES =  \
 	case/cppscan6.rl \
 	case/cppscan6_ruby.rl \
 	case/cppscan6_rust.rl \
+	case/cppscan6_zig.rl \
 	case/curs1_asm.rl \
 	case/curs1_crack.rl \
 	case/curs1_c.rl \
@@ -153,6 +163,7 @@ CASES =  \
 	case/curs1.rl \
 	case/curs1_ruby.rl \
 	case/curs1_rust.rl \
+	case/curs1_zig.rl \
 	case/empty1_asm.rl \
 	case/empty1_crack.rl \
 	case/empty1_c.rl \
@@ -165,6 +176,7 @@ CASES =  \
 	case/empty1.rl \
 	case/empty1_ruby.rl \
 	case/empty1_rust.rl \
+	case/empty1_zig.rl \
 	case/eofact_asm.rl \
 	case/eofact_crack.rl \
 	case/eofact_c.rl \
@@ -177,6 +189,7 @@ CASES =  \
 	case/eofact.rl \
 	case/eofact_ruby.rl \
 	case/eofact_rust.rl \
+	case/eofact_zig.rl \
 	case/erract2_asm.rl \
 	case/erract2_crack.rl \
 	case/erract2_c.rl \
@@ -189,6 +202,7 @@ CASES =  \
 	case/erract2.rl \
 	case/erract2_ruby.rl \
 	case/erract2_rust.rl \
+	case/erract2_zig.rl \
 	case/goto1_asm.rl \
 	case/goto1_crack.rl \
 	case/goto1_c.rl \
@@ -199,6 +213,7 @@ CASES =  \
 	case/goto1_julia.rl \
 	case/goto1.rl \
 	case/goto1_rust.rl \
+	case/goto1_zig.rl \
 	case/gotocallret1_asm.rl \
 	case/gotocallret1_crack.rl \
 	case/gotocallret1_c.rl \
@@ -209,6 +224,7 @@ CASES =  \
 	case/gotocallret1_julia.rl \
 	case/gotocallret1.rl \
 	case/gotocallret1_rust.rl \
+	case/gotocallret1_zig.rl \
 	case/gotocallret2_asm.rl \
 	case/gotocallret2_crack.rl \
 	case/gotocallret2_c.rl \
@@ -219,6 +235,7 @@ CASES =  \
 	case/gotocallret2_julia.rl \
 	case/gotocallret2.rl \
 	case/gotocallret2_rust.rl \
+	case/gotocallret2_zig.rl \
 	case/gotocallret3_asm.rl \
 	case/gotocallret3_crack.rl \
 	case/gotocallret3_c.rl \
@@ -231,6 +248,7 @@ CASES =  \
 	case/gotocallret3.rl \
 	case/gotocallret3_ruby.rl \
 	case/gotocallret3_rust.rl \
+	case/gotocallret3_zig.rl \
 	case/ncall1_asm.rl \
 	case/ncall1_crack.rl \
 	case/ncall1_c.rl \
@@ -243,6 +261,7 @@ CASES =  \
 	case/ncall1.rl \
 	case/ncall1_ruby.rl \
 	case/ncall1_rust.rl \
+	case/ncall1_zig.rl \
 	case/next1_asm.rl \
 	case/next1_crack.rl \
 	case/next1_c.rl \
@@ -255,6 +274,7 @@ CASES =  \
 	case/next1.rl \
 	case/next1_ruby.rl \
 	case/next1_rust.rl \
+	case/next1_zig.rl \
 	case/next2_asm.rl \
 	case/next2_crack.rl \
 	case/next2_c.rl \
@@ -267,6 +287,7 @@ CASES =  \
 	case/next2.rl \
 	case/next2_ruby.rl \
 	case/next2_rust.rl \
+	case/next2_zig.rl \
 	case/patact_asm.rl \
 	case/patact_crack.rl \
 	case/patact_c.rl \
@@ -279,6 +300,7 @@ CASES =  \
 	case/patact.rl \
 	case/patact_ruby.rl \
 	case/patact_rust.rl \
+	case/patact_zig.rl \
 	case/rangei_asm.rl \
 	case/rangei_crack.rl \
 	case/rangei_c.rl \
@@ -291,6 +313,7 @@ CASES =  \
 	case/rangei.rl \
 	case/rangei_ruby.rl \
 	case/rangei_rust.rl \
+	case/rangei_zig.rl \
 	case/scan1_asm.rl \
 	case/scan1_crack.rl \
 	case/scan1_c.rl \
@@ -303,6 +326,7 @@ CASES =  \
 	case/scan1.rl \
 	case/scan1_ruby.rl \
 	case/scan1_rust.rl \
+	case/scan1_zig.rl \
 	case/scan2_asm.rl \
 	case/scan2_crack.rl \
 	case/scan2_c.rl \
@@ -315,6 +339,7 @@ CASES =  \
 	case/scan2.rl \
 	case/scan2_ruby.rl \
 	case/scan2_rust.rl \
+	case/scan2_zig.rl \
 	case/scan3_asm.rl \
 	case/scan3_crack.rl \
 	case/scan3_c.rl \
@@ -327,6 +352,7 @@ CASES =  \
 	case/scan3.rl \
 	case/scan3_ruby.rl \
 	case/scan3_rust.rl \
+	case/scan3_zig.rl \
 	case/scan4_asm.rl \
 	case/scan4_crack.rl \
 	case/scan4_c.rl \
@@ -339,6 +365,7 @@ CASES =  \
 	case/scan4.rl \
 	case/scan4_ruby.rl \
 	case/scan4_rust.rl \
+	case/scan4_zig.rl \
 	case/stateact1_asm.rl \
 	case/stateact1_crack.rl \
 	case/stateact1_c.rl \
@@ -351,6 +378,7 @@ CASES =  \
 	case/stateact1.rl \
 	case/stateact1_ruby.rl \
 	case/stateact1_rust.rl \
+	case/stateact1_zig.rl \
 	case/targs1_asm.rl \
 	case/targs1_crack.rl \
 	case/targs1_c.rl \
@@ -363,6 +391,7 @@ CASES =  \
 	case/targs1.rl \
 	case/targs1_ruby.rl \
 	case/targs1_rust.rl \
+	case/targs1_zig.rl \
 	case/zlen1_asm.rl \
 	case/zlen1_crack.rl \
 	case/zlen1_c.rl \
@@ -374,7 +403,8 @@ CASES =  \
 	case/zlen1_ocaml.rl \
 	case/zlen1.rl \
 	case/zlen1_ruby.rl \
-	case/zlen1_rust.rl
+	case/zlen1_rust.rl \
+	case/zlen1_zig.rl
 
 CLEANFILES = trans.c
 

--- a/test/trans.d/case/any1_zig.rl
+++ b/test/trans.d/case/any1_zig.rl
@@ -1,0 +1,64 @@
+//
+// @LANG: zig
+// @GENERATED: true
+//
+
+const std = @import("std");
+
+// The test harness diffs stdout; std.debug.print is stderr only.
+var _thr: std.Io.Threaded = .init_single_threaded;
+var _obuf: [4096]u8 = undefined;
+var _ow: *std.Io.Writer = undefined;
+
+fn _out( comptime fmt: []const u8, args: anytype ) void
+{
+	_ow.print( fmt, args ) catch {};
+}
+
+
+
+
+%%{
+	machine any1;
+	main := any;
+}%%
+
+
+
+%% write data;
+
+fn m( s: []const u8 ) void
+{
+	const data = s;
+	var p: i32 = 0;
+	var pe: i32 = @intCast( s.len );
+	var eof: i32 = @intCast( s.len );
+	var cs: i32 = 0;
+	var buffer: [1024]u8 = undefined;
+	var blen: usize = 0;
+
+	_ = &data; _ = &p; _ = &pe; _ = &eof; _ = &cs;
+	_ = &buffer; _ = &blen;
+
+	%% write init;
+	%% write exec;
+
+	if ( cs >= any1_first_final ) {
+		_out( "ACCEPT\n", .{} );
+	}
+	else {
+		_out( "FAIL\n", .{} );
+	}
+}
+
+pub fn main() void
+{
+	var _w = std.Io.File.stdout().writer( _thr.io(), &_obuf );
+	_ow = &_w.interface;
+	defer _w.interface.flush() catch {};
+
+	m( "" );
+	m( "x" );
+	m( "xx" );
+}
+

--- a/test/trans.d/case/atoi1_zig.rl
+++ b/test/trans.d/case/atoi1_zig.rl
@@ -1,0 +1,98 @@
+//
+// @LANG: zig
+// @GENERATED: true
+//
+
+const std = @import("std");
+
+// The test harness diffs stdout; std.debug.print is stderr only.
+var _thr: std.Io.Threaded = .init_single_threaded;
+var _obuf: [4096]u8 = undefined;
+var _ow: *std.Io.Writer = undefined;
+
+fn _out( comptime fmt: []const u8, args: anytype ) void
+{
+	_ow.print( fmt, args ) catch {};
+}
+
+var neg: i32 = 0;
+var value: i32 = 0;
+
+%%{
+	machine atoi;
+
+	action begin {neg = 0;
+value = 0;
+}
+
+	action see_neg {neg = 1;
+}
+
+	action add_digit {value = value * 10 + @as( i32, @intCast( fc - 48 ) )
+;
+}
+
+	action finish {if ( neg != 0 )
+{
+	value = -1 * value;
+
+}
+}
+	action print {_out( "{d}", .{ value } );
+_out( "{s}", .{ "\n" } );
+}
+
+	atoi = (
+		('-'@see_neg | '+')? (digit @add_digit)+
+	) >begin %finish;
+
+	main := atoi '\n' @print;
+}%%
+
+
+
+%% write data;
+
+fn m( s: []const u8 ) void
+{
+	const data = s;
+	var p: i32 = 0;
+	var pe: i32 = @intCast( s.len );
+	var eof: i32 = @intCast( s.len );
+	var cs: i32 = 0;
+	var buffer: [1024]u8 = undefined;
+	var blen: usize = 0;
+
+	_ = &data; _ = &p; _ = &pe; _ = &eof; _ = &cs;
+	_ = &buffer; _ = &blen;
+value = 0;
+neg = 0;
+
+	%% write init;
+	%% write exec;
+
+	if ( cs >= atoi_first_final ) {
+		_out( "ACCEPT\n", .{} );
+	}
+	else {
+		_out( "FAIL\n", .{} );
+	}
+}
+
+pub fn main() void
+{
+	var _w = std.Io.File.stdout().writer( _thr.io(), &_obuf );
+	_ow = &_w.interface;
+	defer _w.interface.flush() catch {};
+
+	m( "1\n" );
+	m( "12\n" );
+	m( "222222\n" );
+	m( "+2123\n" );
+	m( "213 3213\n" );
+	m( "-12321\n" );
+	m( "--123\n" );
+	m( "-99\n" );
+	m( " -3000\n" );
+}
+

--- a/test/trans.d/case/atoi2_zig.rl
+++ b/test/trans.d/case/atoi2_zig.rl
@@ -1,0 +1,113 @@
+//
+// @LANG: zig
+// @GENERATED: true
+//
+
+const std = @import("std");
+
+// The test harness diffs stdout; std.debug.print is stderr only.
+var _thr: std.Io.Threaded = .init_single_threaded;
+var _obuf: [4096]u8 = undefined;
+var _ow: *std.Io.Writer = undefined;
+
+fn _out( comptime fmt: []const u8, args: anytype ) void
+{
+	_ow.print( fmt, args ) catch {};
+}
+
+var neg: i32 = 0;
+var value: i32 = 0;
+
+%%{
+	machine state_chart;
+
+	action begin {neg = 0;
+value = 0;
+}
+
+	action see_neg {neg = 1;
+}
+
+	action add_digit {value = value * 10 + @as( i32, @intCast( fc - 48 ) )
+;
+}
+
+	action finish {if ( neg != 0 )
+{
+	value = -1 * value;
+
+}
+}
+
+	atoi = (
+		start: (
+			'-' @see_neg ->om_num | 
+			'+' ->om_num |
+			[0-9] @add_digit ->more_nums
+		),
+
+		# One or more nums.
+		om_num: (
+			[0-9] @add_digit ->more_nums
+		),
+
+		# Zero ore more nums.
+		more_nums: (
+			[0-9] @add_digit ->more_nums |
+			'' -> final
+		)
+	) >begin %finish;
+
+	action oneof {_out( "{d}", .{ value } );
+_out( "{s}", .{ "\n" } );
+}
+	main := ( atoi '\n' @oneof )*;
+}%%
+
+
+
+%% write data;
+
+fn m( s: []const u8 ) void
+{
+	const data = s;
+	var p: i32 = 0;
+	var pe: i32 = @intCast( s.len );
+	var eof: i32 = @intCast( s.len );
+	var cs: i32 = 0;
+	var buffer: [1024]u8 = undefined;
+	var blen: usize = 0;
+
+	_ = &data; _ = &p; _ = &pe; _ = &eof; _ = &cs;
+	_ = &buffer; _ = &blen;
+value = 0;
+neg = 0;
+
+	%% write init;
+	%% write exec;
+
+	if ( cs >= state_chart_first_final ) {
+		_out( "ACCEPT\n", .{} );
+	}
+	else {
+		_out( "FAIL\n", .{} );
+	}
+}
+
+pub fn main() void
+{
+	var _w = std.Io.File.stdout().writer( _thr.io(), &_obuf );
+	_ow = &_w.interface;
+	defer _w.interface.flush() catch {};
+
+	m( "1\n" );
+	m( "12\n" );
+	m( "222222\n" );
+	m( "+2123\n" );
+	m( "213 3213\n" );
+	m( "-12321\n" );
+	m( "--123\n" );
+	m( "-99\n" );
+	m( " -3000\n" );
+}
+

--- a/test/trans.d/case/call4_zig.rl
+++ b/test/trans.d/case/call4_zig.rl
@@ -1,0 +1,78 @@
+//
+// @LANG: zig
+// @GENERATED: true
+//
+
+const std = @import("std");
+
+// The test harness diffs stdout; std.debug.print is stderr only.
+var _thr: std.Io.Threaded = .init_single_threaded;
+var _obuf: [4096]u8 = undefined;
+var _ow: *std.Io.Writer = undefined;
+
+fn _out( comptime fmt: []const u8, args: anytype ) void
+{
+	_ow.print( fmt, args ) catch {};
+}
+
+var target: i32 = 0;
+var top: i32 = 0;
+var stack: [32]i32 = .{ 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 };
+
+%%{
+	machine call4;
+
+	unused := 'unused';
+
+	one := 'one' @{_out( "{s}", .{ "one\n" } );
+fret;};
+
+	two := 'two' @{_out( "{s}", .{ "two\n" } );
+fret;};
+
+	main := (
+			'1' @{target = fentry(one);
+fcall *target;}
+		|	'2' @{target = fentry(two);
+fcall *target;}
+		|	'\n'
+	)*;
+}%%
+
+
+
+%% write data;
+
+fn m( s: []const u8 ) void
+{
+	const data = s;
+	var p: i32 = 0;
+	var pe: i32 = @intCast( s.len );
+	var eof: i32 = @intCast( s.len );
+	var cs: i32 = 0;
+	var buffer: [1024]u8 = undefined;
+	var blen: usize = 0;
+
+	_ = &data; _ = &p; _ = &pe; _ = &eof; _ = &cs;
+	_ = &buffer; _ = &blen;
+
+	%% write init;
+	%% write exec;
+
+	if ( cs >= call4_first_final ) {
+		_out( "ACCEPT\n", .{} );
+	}
+	else {
+		_out( "FAIL\n", .{} );
+	}
+}
+
+pub fn main() void
+{
+	var _w = std.Io.File.stdout().writer( _thr.io(), &_obuf );
+	_ow = &_w.interface;
+	defer _w.interface.flush() catch {};
+
+	m( "1one2two1one\n" );
+}
+

--- a/test/trans.d/case/caseindep_zig.rl
+++ b/test/trans.d/case/caseindep_zig.rl
@@ -1,0 +1,86 @@
+//
+// @LANG: zig
+// @GENERATED: true
+//
+
+const std = @import("std");
+
+// The test harness diffs stdout; std.debug.print is stderr only.
+var _thr: std.Io.Threaded = .init_single_threaded;
+var _obuf: [4096]u8 = undefined;
+var _ow: *std.Io.Writer = undefined;
+
+fn _out( comptime fmt: []const u8, args: anytype ) void
+{
+	_ow.print( fmt, args ) catch {};
+}
+
+
+
+%%{
+	machine indep;
+
+	main := (
+		( '1' 'hello' ) |
+		( '2' "hello" ) |
+		( '3' /hello/ ) |
+		( '4' 'hello'i ) |
+		( '5' "hello"i ) |
+		( '6' /hello/i )
+	) '\n';
+}%%
+
+
+
+%% write data;
+
+fn m( s: []const u8 ) void
+{
+	const data = s;
+	var p: i32 = 0;
+	var pe: i32 = @intCast( s.len );
+	var eof: i32 = @intCast( s.len );
+	var cs: i32 = 0;
+	var buffer: [1024]u8 = undefined;
+	var blen: usize = 0;
+
+	_ = &data; _ = &p; _ = &pe; _ = &eof; _ = &cs;
+	_ = &buffer; _ = &blen;
+
+	%% write init;
+	%% write exec;
+
+	if ( cs >= indep_first_final ) {
+		_out( "ACCEPT\n", .{} );
+	}
+	else {
+		_out( "FAIL\n", .{} );
+	}
+}
+
+pub fn main() void
+{
+	var _w = std.Io.File.stdout().writer( _thr.io(), &_obuf );
+	_ow = &_w.interface;
+	defer _w.interface.flush() catch {};
+
+	m( "1hello\n" );
+	m( "1HELLO\n" );
+	m( "1HeLLo\n" );
+	m( "2hello\n" );
+	m( "2HELLO\n" );
+	m( "2HeLLo\n" );
+	m( "3hello\n" );
+	m( "3HELLO\n" );
+	m( "3HeLLo\n" );
+	m( "4hello\n" );
+	m( "4HELLO\n" );
+	m( "4HeLLo\n" );
+	m( "5hello\n" );
+	m( "5HELLO\n" );
+	m( "5HeLLo\n" );
+	m( "6hello\n" );
+	m( "6HELLO\n" );
+	m( "6HeLLo\n" );
+}
+

--- a/test/trans.d/case/clang4_zig.rl
+++ b/test/trans.d/case/clang4_zig.rl
@@ -1,0 +1,202 @@
+//
+// @LANG: zig
+// @GENERATED: true
+//
+
+const std = @import("std");
+
+// The test harness diffs stdout; std.debug.print is stderr only.
+var _thr: std.Io.Threaded = .init_single_threaded;
+var _obuf: [4096]u8 = undefined;
+var _ow: *std.Io.Writer = undefined;
+
+fn _out( comptime fmt: []const u8, args: anytype ) void
+{
+	_ow.print( fmt, args ) catch {};
+}
+
+var pos: i32 = 0;
+var line: i32 = 0;
+
+%%{
+	machine clang;
+
+	# Function to buffer a character.
+	action bufChar {	buffer[blen] = fc; blen += 1;
+}
+
+	# Function to clear the buffer.
+	action clearBuf {	blen = 0;
+}
+
+	action incLine {line = line + 1;
+}
+
+	# Functions to dump tokens as they are matched.
+	action ident {_out( "{s}", .{ "ident(" } );
+_out( "{d}", .{ line } );
+_out( "{s}", .{ "," } );
+_out( "{d}", .{ @as( i32, @intCast( blen ) ) } );
+_out( "{s}", .{ "): " } );
+_out( "{s}", .{ buffer[0..blen] } );
+_out( "{s}", .{ "\n" } );
+}
+	action literal {_out( "{s}", .{ "literal(" } );
+_out( "{d}", .{ line } );
+_out( "{s}", .{ "," } );
+_out( "{d}", .{ @as( i32, @intCast( blen ) ) } );
+_out( "{s}", .{ "): " } );
+_out( "{s}", .{ buffer[0..blen] } );
+_out( "{s}", .{ "\n" } );
+}
+	action float {_out( "{s}", .{ "float(" } );
+_out( "{d}", .{ line } );
+_out( "{s}", .{ "," } );
+_out( "{d}", .{ @as( i32, @intCast( blen ) ) } );
+_out( "{s}", .{ "): " } );
+_out( "{s}", .{ buffer[0..blen] } );
+_out( "{s}", .{ "\n" } );
+}
+	action integer {_out( "{s}", .{ "int(" } );
+_out( "{d}", .{ line } );
+_out( "{s}", .{ "," } );
+_out( "{d}", .{ @as( i32, @intCast( blen ) ) } );
+_out( "{s}", .{ "): " } );
+_out( "{s}", .{ buffer[0..blen] } );
+_out( "{s}", .{ "\n" } );
+}
+	action hex {_out( "{s}", .{ "hex(" } );
+_out( "{d}", .{ line } );
+_out( "{s}", .{ "," } );
+_out( "{d}", .{ @as( i32, @intCast( blen ) ) } );
+_out( "{s}", .{ "): " } );
+_out( "{s}", .{ buffer[0..blen] } );
+_out( "{s}", .{ "\n" } );
+}
+	action symbol {_out( "{s}", .{ "symbol(" } );
+_out( "{d}", .{ line } );
+_out( "{s}", .{ "," } );
+_out( "{d}", .{ @as( i32, @intCast( blen ) ) } );
+_out( "{s}", .{ "): " } );
+_out( "{s}", .{ buffer[0..blen] } );
+_out( "{s}", .{ "\n" } );
+}
+
+	# Alpha numberic characters or underscore.
+	alnumu = alnum | '_';
+
+	# Alpha charactres or underscore.
+	alphau = alpha | '_';
+
+	# Symbols. Upon entering clear the buffer. On all transitions
+	# buffer a character. Upon leaving dump the symbol.
+	symbol = ( punct - [_'"] ) >clearBuf $bufChar %symbol;
+
+	# Identifier. Upon entering clear the buffer. On all transitions
+	# buffer a character. Upon leaving, dump the identifier.
+	ident = (alphau . alnumu*) >clearBuf $bufChar %ident;
+
+	# Match single characters inside literal strings. Or match 
+	# an escape sequence. Buffers the charater matched.
+	sliteralChar =
+			( extend - ['\\] ) @bufChar |
+			( '\\' . extend @bufChar );
+	dliteralChar =
+			( extend - ["\\] ) @bufChar |
+			( '\\' . extend @bufChar );
+
+	# Single quote and double quota literals. At the start clear
+	# the buffer. Upon leaving dump the literal.
+	sliteral = ('\'' @clearBuf . sliteralChar* . '\'' ) %literal;
+	dliteral = ('"' @clearBuf . dliteralChar* . '"' ) %literal;
+	literal = sliteral | dliteral;
+
+	# Whitespace is standard ws, newlines and control codes.
+	whitespace = any - 33 .. 126;
+
+	# Describe both c style comments and c++ style comments. The
+	# priority bump on tne terminator of the comments brings us
+	# out of the extend* which matches everything.
+	ccComment = '//' . extend* $0 . '\n' @1;
+	cComment = '/!' . extend* $0 . '!/' @1;
+
+	# Match an integer. We don't bother clearing the buf or filling it.
+	# The float machine overlaps with int and it will do it.
+	integer = digit+ %integer;
+
+	# Match a float. Upon entering the machine clear the buf, buffer
+	# characters on every trans and dump the float upon leaving.
+	float =  ( digit+ . '.' . digit+ ) >clearBuf $bufChar %float;
+
+	# Match a hex. Upon entering the hex part, clear the buf, buffer characters
+	# on every trans and dump the hex on leaving transitions.
+	hex = '0x' . xdigit+ >clearBuf $bufChar %hex;
+
+	# Or together all the lanuage elements.
+	fin = ( ccComment |
+		cComment |
+		symbol |
+		ident |
+		literal |
+		whitespace |
+		integer |
+		float |
+		hex );
+
+	# Star the language elements. It is critical in this type of application
+	# that we decrease the priority of out transitions before doing so. This
+	# is so that when we see 'aa' we stay in the fin machine to match an ident
+	# of length two and not wrap around to the front to match two idents of 
+	# length one.
+	clang_main = ( fin $1 %0 )*;
+
+	# This machine matches everything, taking note of newlines.
+	newline = ( any | '\n' @incLine )*;
+
+	# The final fsm is the lexer intersected with the newline machine which
+	# will count lines for us. Since the newline machine accepts everything,
+	# the strings accepted is goverened by the clang_main machine, onto which
+	# the newline machine overlays line counting.
+	main := clang_main & newline;
+}%%
+
+
+
+%% write data;
+
+fn m( s: []const u8 ) void
+{
+	const data = s;
+	var p: i32 = 0;
+	var pe: i32 = @intCast( s.len );
+	var eof: i32 = @intCast( s.len );
+	var cs: i32 = 0;
+	var buffer: [1024]u8 = undefined;
+	var blen: usize = 0;
+
+	_ = &data; _ = &p; _ = &pe; _ = &eof; _ = &cs;
+	_ = &buffer; _ = &blen;
+pos = 0;
+line = 1;
+
+	%% write init;
+	%% write exec;
+
+	if ( cs >= clang_first_final ) {
+		_out( "ACCEPT\n", .{} );
+	}
+	else {
+		_out( "FAIL\n", .{} );
+	}
+}
+
+pub fn main() void
+{
+	var _w = std.Io.File.stdout().writer( _thr.io(), &_obuf );
+	_ow = &_w.interface;
+	defer _w.interface.flush() catch {};
+
+	m( "999 0xaAFF99 99.99 /!\n!/ 'lksdj' //\n\"\n\nliteral\n\n\n\"0x00aba foobardd.ddsf 0x0.9\n" );
+	m( "wordwithnum00asdf\n000wordfollowsnum,makes new symbol\n\nfinishing early /! unfinished ...\n" );
+}
+

--- a/test/trans.d/case/cond1_zig.rl
+++ b/test/trans.d/case/cond1_zig.rl
@@ -1,0 +1,123 @@
+//
+// @LANG: zig
+// @GENERATED: true
+//
+
+const std = @import("std");
+
+// The test harness diffs stdout; std.debug.print is stderr only.
+var _thr: std.Io.Threaded = .init_single_threaded;
+var _obuf: [4096]u8 = undefined;
+var _ow: *std.Io.Writer = undefined;
+
+fn _out( comptime fmt: []const u8, args: anytype ) void
+{
+	_ow.print( fmt, args ) catch {};
+}
+
+var i: i32 = 0;
+var j: i32 = 0;
+var k: i32 = 0;
+
+%%{
+	machine foo;
+
+	action c1 {i != 0}
+	action c2 {j != 0}
+	action c3 {k != 0}
+	action one {_out( "{s}", .{ "  one\n" } );
+}
+	action two {_out( "{s}", .{ "  two\n" } );
+}
+	action three {_out( "{s}", .{ "  three\n" } );
+}
+
+	action seti {if ( fc == 48 )
+{
+	i = 0;
+
+}
+else {
+	i = 1;
+
+}
+}
+	action setj {if ( fc == 48 )
+{
+	j = 0;
+
+}
+else {
+	j = 1;
+
+}
+}
+	action setk {if ( fc == 48 )
+{
+	k = 0;
+
+}
+else {
+	k = 1;
+
+}
+}
+
+	action break {fnbreak;}
+
+	one = 'a' 'b' when c1 'c' @one;
+	two = 'a'* 'b' when c2 'c' @two;
+	three = 'a'+ 'b' when c3 'c' @three;
+
+	main := 
+		[01] @seti
+		[01] @setj
+		[01] @setk
+		( one | two | three ) '\n' @break;
+	
+}%%
+
+
+
+%% write data;
+
+fn m( s: []const u8 ) void
+{
+	const data = s;
+	var p: i32 = 0;
+	var pe: i32 = @intCast( s.len );
+	var eof: i32 = @intCast( s.len );
+	var cs: i32 = 0;
+	var buffer: [1024]u8 = undefined;
+	var blen: usize = 0;
+
+	_ = &data; _ = &p; _ = &pe; _ = &eof; _ = &cs;
+	_ = &buffer; _ = &blen;
+
+	%% write init;
+	%% write exec;
+
+	if ( cs >= foo_first_final ) {
+		_out( "ACCEPT\n", .{} );
+	}
+	else {
+		_out( "FAIL\n", .{} );
+	}
+}
+
+pub fn main() void
+{
+	var _w = std.Io.File.stdout().writer( _thr.io(), &_obuf );
+	_ow = &_w.interface;
+	defer _w.interface.flush() catch {};
+
+	m( "000abc\n" );
+	m( "100abc\n" );
+	m( "010abc\n" );
+	m( "110abc\n" );
+	m( "001abc\n" );
+	m( "101abc\n" );
+	m( "011abc\n" );
+	m( "111abc\n" );
+}
+

--- a/test/trans.d/case/cond7_zig.rl
+++ b/test/trans.d/case/cond7_zig.rl
@@ -1,0 +1,89 @@
+//
+// @LANG: zig
+// @GENERATED: true
+//
+
+const std = @import("std");
+
+// The test harness diffs stdout; std.debug.print is stderr only.
+var _thr: std.Io.Threaded = .init_single_threaded;
+var _obuf: [4096]u8 = undefined;
+var _ow: *std.Io.Writer = undefined;
+
+fn _out( comptime fmt: []const u8, args: anytype ) void
+{
+	_ow.print( fmt, args ) catch {};
+}
+
+var i: i32 = 0;
+var c: i32 = 0;
+
+%%{
+	machine foo;
+
+	action testi {i > 0}
+	action inc {i = i - 1;
+c = @as( i32, @intCast( fc ) )
+;
+_out( "{s}", .{ "item: " } );
+_out( "{d}", .{ c } );
+_out( "{s}", .{ "\n" } );
+}
+
+	count = [0-9] @{i = @as( i32, @intCast( fc - 48 ) )
+;
+_out( "{s}", .{ "count: " } );
+_out( "{d}", .{ i } );
+_out( "{s}", .{ "\n" } );
+};
+
+    sub = 	
+		count # record the number of digits 
+		( digit when testi @inc )* outwhen !testi;
+	
+    main := sub sub '\n';
+}%%
+
+
+
+%% write data;
+
+fn m( s: []const u8 ) void
+{
+	const data = s;
+	var p: i32 = 0;
+	var pe: i32 = @intCast( s.len );
+	var eof: i32 = @intCast( s.len );
+	var cs: i32 = 0;
+	var buffer: [1024]u8 = undefined;
+	var blen: usize = 0;
+
+	_ = &data; _ = &p; _ = &pe; _ = &eof; _ = &cs;
+	_ = &buffer; _ = &blen;
+
+	%% write init;
+	%% write exec;
+
+	if ( cs >= foo_first_final ) {
+		_out( "ACCEPT\n", .{} );
+	}
+	else {
+		_out( "FAIL\n", .{} );
+	}
+}
+
+pub fn main() void
+{
+	var _w = std.Io.File.stdout().writer( _thr.io(), &_obuf );
+	_ow = &_w.interface;
+	defer _w.interface.flush() catch {};
+
+	m( "00\n" );
+	m( "019\n" );
+	m( "190\n" );
+	m( "1719\n" );
+	m( "1040000\n" );
+	m( "104000a\n" );
+	m( "104000\n" );
+}
+

--- a/test/trans.d/case/cppscan6_zig.rl
+++ b/test/trans.d/case/cppscan6_zig.rl
@@ -1,0 +1,308 @@
+//
+// @LANG: zig
+// @GENERATED: true
+//
+
+const std = @import("std");
+
+// The test harness diffs stdout; std.debug.print is stderr only.
+var _thr: std.Io.Threaded = .init_single_threaded;
+var _obuf: [4096]u8 = undefined;
+var _ow: *std.Io.Writer = undefined;
+
+fn _out( comptime fmt: []const u8, args: anytype ) void
+{
+	_ow.print( fmt, args ) catch {};
+}
+
+var ts: i32 = 0;
+var te: i32 = 0;
+var act: i32 = 0;
+var token: i32 = 0;
+
+%%{
+	machine scanner;
+
+	action comment {token = 242;
+_out( "{s}", .{ "<" } );
+_out( "{d}", .{ token } );
+_out( "{s}", .{ "> " } );
+_out( "{s}", .{ data[@intCast(ts)..@intCast(te)] } );
+_out( "{s}", .{ "\n" } );
+}
+
+
+	main := |*
+
+	# Single and double literals.
+	( 'L'? "'" ( [^'\\\n] | '\\' any )* "'" ) 
+		=> {token = 193;
+_out( "{s}", .{ "<" } );
+_out( "{d}", .{ token } );
+_out( "{s}", .{ "> " } );
+_out( "{s}", .{ data[@intCast(ts)..@intCast(te)] } );
+_out( "{s}", .{ "\n" } );
+};
+	( 'L'? '"' ( [^"\\\n] | '\\' any )* '"' ) 
+		=> {token = 192;
+_out( "{s}", .{ "<" } );
+_out( "{d}", .{ token } );
+_out( "{s}", .{ "> " } );
+_out( "{s}", .{ data[@intCast(ts)..@intCast(te)] } );
+_out( "{s}", .{ "\n" } );
+};
+
+	# Identifiers
+	( [a-zA-Z_] [a-zA-Z0-9_]* ) 
+		=>{token = 195;
+_out( "{s}", .{ "<" } );
+_out( "{d}", .{ token } );
+_out( "{s}", .{ "> " } );
+_out( "{s}", .{ data[@intCast(ts)..@intCast(te)] } );
+_out( "{s}", .{ "\n" } );
+};
+
+	# Floating literals.
+	fract_const = digit* '.' digit+ | digit+ '.';
+	exponent = [eE] [+\-]? digit+;
+	float_suffix = [flFL];
+
+	( fract_const exponent? float_suffix? |
+		digit+ exponent float_suffix? ) 
+		=> {token = 194;
+_out( "{s}", .{ "<" } );
+_out( "{d}", .{ token } );
+_out( "{s}", .{ "> " } );
+_out( "{s}", .{ data[@intCast(ts)..@intCast(te)] } );
+_out( "{s}", .{ "\n" } );
+};
+	
+	# Integer decimal. Leading part buffered by float.
+	( ( '0' | [1-9] [0-9]* ) [ulUL]? ) 
+		=> {token = 218;
+_out( "{s}", .{ "<" } );
+_out( "{d}", .{ token } );
+_out( "{s}", .{ "> " } );
+_out( "{s}", .{ data[@intCast(ts)..@intCast(te)] } );
+_out( "{s}", .{ "\n" } );
+};
+
+	# Integer octal. Leading part buffered by float.
+	( '0' [0-9]+ [ulUL]? ) 
+		=> {token = 219;
+_out( "{s}", .{ "<" } );
+_out( "{d}", .{ token } );
+_out( "{s}", .{ "> " } );
+_out( "{s}", .{ data[@intCast(ts)..@intCast(te)] } );
+_out( "{s}", .{ "\n" } );
+};
+
+	# Integer hex. Leading 0 buffered by float.
+	( '0' ( 'x' [0-9a-fA-F]+ [ulUL]? ) ) 
+		=> {token = 220;
+_out( "{s}", .{ "<" } );
+_out( "{d}", .{ token } );
+_out( "{s}", .{ "> " } );
+_out( "{s}", .{ data[@intCast(ts)..@intCast(te)] } );
+_out( "{s}", .{ "\n" } );
+};
+
+	# Only buffer the second item, first buffered by symbol.
+	'::' => {token = 197;
+_out( "{s}", .{ "<" } );
+_out( "{d}", .{ token } );
+_out( "{s}", .{ "> " } );
+_out( "{s}", .{ data[@intCast(ts)..@intCast(te)] } );
+_out( "{s}", .{ "\n" } );
+};
+	'==' => {token = 223;
+_out( "{s}", .{ "<" } );
+_out( "{d}", .{ token } );
+_out( "{s}", .{ "> " } );
+_out( "{s}", .{ data[@intCast(ts)..@intCast(te)] } );
+_out( "{s}", .{ "\n" } );
+};
+	'!=' => {token = 224;
+_out( "{s}", .{ "<" } );
+_out( "{d}", .{ token } );
+_out( "{s}", .{ "> " } );
+_out( "{s}", .{ data[@intCast(ts)..@intCast(te)] } );
+_out( "{s}", .{ "\n" } );
+};
+	'&&' => {token = 225;
+_out( "{s}", .{ "<" } );
+_out( "{d}", .{ token } );
+_out( "{s}", .{ "> " } );
+_out( "{s}", .{ data[@intCast(ts)..@intCast(te)] } );
+_out( "{s}", .{ "\n" } );
+};
+	'||' => {token = 226;
+_out( "{s}", .{ "<" } );
+_out( "{d}", .{ token } );
+_out( "{s}", .{ "> " } );
+_out( "{s}", .{ data[@intCast(ts)..@intCast(te)] } );
+_out( "{s}", .{ "\n" } );
+};
+	'*=' => {token = 227;
+_out( "{s}", .{ "<" } );
+_out( "{d}", .{ token } );
+_out( "{s}", .{ "> " } );
+_out( "{s}", .{ data[@intCast(ts)..@intCast(te)] } );
+_out( "{s}", .{ "\n" } );
+};
+	'/=' => {token = 228;
+_out( "{s}", .{ "<" } );
+_out( "{d}", .{ token } );
+_out( "{s}", .{ "> " } );
+_out( "{s}", .{ data[@intCast(ts)..@intCast(te)] } );
+_out( "{s}", .{ "\n" } );
+};
+	'%=' => {token = 229;
+_out( "{s}", .{ "<" } );
+_out( "{d}", .{ token } );
+_out( "{s}", .{ "> " } );
+_out( "{s}", .{ data[@intCast(ts)..@intCast(te)] } );
+_out( "{s}", .{ "\n" } );
+};
+	'+=' => {token = 230;
+_out( "{s}", .{ "<" } );
+_out( "{d}", .{ token } );
+_out( "{s}", .{ "> " } );
+_out( "{s}", .{ data[@intCast(ts)..@intCast(te)] } );
+_out( "{s}", .{ "\n" } );
+};
+	'-=' => {token = 231;
+_out( "{s}", .{ "<" } );
+_out( "{d}", .{ token } );
+_out( "{s}", .{ "> " } );
+_out( "{s}", .{ data[@intCast(ts)..@intCast(te)] } );
+_out( "{s}", .{ "\n" } );
+};
+	'&=' => {token = 232;
+_out( "{s}", .{ "<" } );
+_out( "{d}", .{ token } );
+_out( "{s}", .{ "> " } );
+_out( "{s}", .{ data[@intCast(ts)..@intCast(te)] } );
+_out( "{s}", .{ "\n" } );
+};
+	'^=' => {token = 233;
+_out( "{s}", .{ "<" } );
+_out( "{d}", .{ token } );
+_out( "{s}", .{ "> " } );
+_out( "{s}", .{ data[@intCast(ts)..@intCast(te)] } );
+_out( "{s}", .{ "\n" } );
+};
+	'|=' => {token = 234;
+_out( "{s}", .{ "<" } );
+_out( "{d}", .{ token } );
+_out( "{s}", .{ "> " } );
+_out( "{s}", .{ data[@intCast(ts)..@intCast(te)] } );
+_out( "{s}", .{ "\n" } );
+};
+	'++' => {token = 212;
+_out( "{s}", .{ "<" } );
+_out( "{d}", .{ token } );
+_out( "{s}", .{ "> " } );
+_out( "{s}", .{ data[@intCast(ts)..@intCast(te)] } );
+_out( "{s}", .{ "\n" } );
+};
+	'--' => {token = 213;
+_out( "{s}", .{ "<" } );
+_out( "{d}", .{ token } );
+_out( "{s}", .{ "> " } );
+_out( "{s}", .{ data[@intCast(ts)..@intCast(te)] } );
+_out( "{s}", .{ "\n" } );
+};
+	'->' => {token = 211;
+_out( "{s}", .{ "<" } );
+_out( "{d}", .{ token } );
+_out( "{s}", .{ "> " } );
+_out( "{s}", .{ data[@intCast(ts)..@intCast(te)] } );
+_out( "{s}", .{ "\n" } );
+};
+	'->*' => {token = 214;
+_out( "{s}", .{ "<" } );
+_out( "{d}", .{ token } );
+_out( "{s}", .{ "> " } );
+_out( "{s}", .{ data[@intCast(ts)..@intCast(te)] } );
+_out( "{s}", .{ "\n" } );
+};
+	'.*' => {token = 215;
+_out( "{s}", .{ "<" } );
+_out( "{d}", .{ token } );
+_out( "{s}", .{ "> " } );
+_out( "{s}", .{ data[@intCast(ts)..@intCast(te)] } );
+_out( "{s}", .{ "\n" } );
+};
+
+	# Three char compounds, first item already buffered.
+	'...' => {token = 240;
+_out( "{s}", .{ "<" } );
+_out( "{d}", .{ token } );
+_out( "{s}", .{ "> " } );
+_out( "{s}", .{ data[@intCast(ts)..@intCast(te)] } );
+_out( "{s}", .{ "\n" } );
+};
+
+	# Single char symbols.
+	( punct - [_"'] ) => {token = @as( i32, @intCast( data[@intCast(ts)] ) )
+;
+_out( "{s}", .{ "<" } );
+_out( "{d}", .{ token } );
+_out( "{s}", .{ "> " } );
+_out( "{s}", .{ data[@intCast(ts)..@intCast(te)] } );
+_out( "{s}", .{ "\n" } );
+};
+
+	# Comments and whitespace.
+	'/!' ( any* $0 '!/' @1 ) => comment;
+	'//' ( any* $0 '\n' @1 ) => comment;
+	( any - 33..126 )+ => {token = 241;
+_out( "{s}", .{ "<" } );
+_out( "{d}", .{ token } );
+_out( "{s}", .{ "> " } );
+_out( "{s}", .{ data[@intCast(ts)..@intCast(te)] } );
+_out( "{s}", .{ "\n" } );
+};
+	*|;
+}%%
+
+
+
+%% write data;
+
+fn m( s: []const u8 ) void
+{
+	const data = s;
+	var p: i32 = 0;
+	var pe: i32 = @intCast( s.len );
+	var eof: i32 = @intCast( s.len );
+	var cs: i32 = 0;
+	var buffer: [1024]u8 = undefined;
+	var blen: usize = 0;
+
+	_ = &data; _ = &p; _ = &pe; _ = &eof; _ = &cs;
+	_ = &buffer; _ = &blen;
+
+	%% write init;
+	%% write exec;
+
+	if ( cs >= scanner_first_final ) {
+		_out( "ACCEPT\n", .{} );
+	}
+	else {
+		_out( "FAIL\n", .{} );
+	}
+}
+
+pub fn main() void
+{
+	var _w = std.Io.File.stdout().writer( _thr.io(), &_obuf );
+	_ow = &_w.interface;
+	defer _w.interface.flush() catch {};
+
+	m( "\"\\\"hi\" /!\n!/\n44 .44\n44. 44\n44 . 44\n44.44\n_hithere22" );
+	m( "'\\''\"\\n\\d'\\\"\"\nhi\n99\n.99\n99e-4\n->*\n||\n0x98\n0x\n//\n/! * !/" );
+	m( "'\n'\n" );
+}
+

--- a/test/trans.d/case/curs1_zig.rl
+++ b/test/trans.d/case/curs1_zig.rl
@@ -1,0 +1,75 @@
+//
+// @LANG: zig
+// @GENERATED: true
+//
+
+const std = @import("std");
+
+// The test harness diffs stdout; std.debug.print is stderr only.
+var _thr: std.Io.Threaded = .init_single_threaded;
+var _obuf: [4096]u8 = undefined;
+var _ow: *std.Io.Writer = undefined;
+
+fn _out( comptime fmt: []const u8, args: anytype ) void
+{
+	_ow.print( fmt, args ) catch {};
+}
+
+var return_to: i32 = 0;
+
+%%{
+	machine curs1;
+
+	unused := 'unused';
+
+	one := 'one' @{_out( "{s}", .{ "one\n" } );
+fnext *return_to;};
+
+	two := 'two' @{_out( "{s}", .{ "two\n" } );
+fnext *return_to;};
+
+	main := 
+		'1' @{return_to = fcurs;
+fnext one;}
+	|	'2' @{return_to = fcurs;
+fnext two;}
+	|	'\n';
+}%%
+
+
+
+%% write data;
+
+fn m( s: []const u8 ) void
+{
+	const data = s;
+	var p: i32 = 0;
+	var pe: i32 = @intCast( s.len );
+	var eof: i32 = @intCast( s.len );
+	var cs: i32 = 0;
+	var buffer: [1024]u8 = undefined;
+	var blen: usize = 0;
+
+	_ = &data; _ = &p; _ = &pe; _ = &eof; _ = &cs;
+	_ = &buffer; _ = &blen;
+
+	%% write init;
+	%% write exec;
+
+	if ( cs >= curs1_first_final ) {
+		_out( "ACCEPT\n", .{} );
+	}
+	else {
+		_out( "FAIL\n", .{} );
+	}
+}
+
+pub fn main() void
+{
+	var _w = std.Io.File.stdout().writer( _thr.io(), &_obuf );
+	_ow = &_w.interface;
+	defer _w.interface.flush() catch {};
+
+	m( "1one2two1one\n" );
+}
+

--- a/test/trans.d/case/empty1_zig.rl
+++ b/test/trans.d/case/empty1_zig.rl
@@ -1,0 +1,63 @@
+//
+// @LANG: zig
+// @GENERATED: true
+//
+
+const std = @import("std");
+
+// The test harness diffs stdout; std.debug.print is stderr only.
+var _thr: std.Io.Threaded = .init_single_threaded;
+var _obuf: [4096]u8 = undefined;
+var _ow: *std.Io.Writer = undefined;
+
+fn _out( comptime fmt: []const u8, args: anytype ) void
+{
+	_ow.print( fmt, args ) catch {};
+}
+
+
+
+
+%%{
+	machine empty1;
+	main := empty;
+}%%
+
+
+
+%% write data;
+
+fn m( s: []const u8 ) void
+{
+	const data = s;
+	var p: i32 = 0;
+	var pe: i32 = @intCast( s.len );
+	var eof: i32 = @intCast( s.len );
+	var cs: i32 = 0;
+	var buffer: [1024]u8 = undefined;
+	var blen: usize = 0;
+
+	_ = &data; _ = &p; _ = &pe; _ = &eof; _ = &cs;
+	_ = &buffer; _ = &blen;
+
+	%% write init;
+	%% write exec;
+
+	if ( cs >= empty1_first_final ) {
+		_out( "ACCEPT\n", .{} );
+	}
+	else {
+		_out( "FAIL\n", .{} );
+	}
+}
+
+pub fn main() void
+{
+	var _w = std.Io.File.stdout().writer( _thr.io(), &_obuf );
+	_ow = &_w.interface;
+	defer _w.interface.flush() catch {};
+
+	m( "" );
+	m( "x" );
+}
+

--- a/test/trans.d/case/eofact_zig.rl
+++ b/test/trans.d/case/eofact_zig.rl
@@ -1,0 +1,85 @@
+//
+// @LANG: zig
+// @GENERATED: true
+//
+
+const std = @import("std");
+
+// The test harness diffs stdout; std.debug.print is stderr only.
+var _thr: std.Io.Threaded = .init_single_threaded;
+var _obuf: [4096]u8 = undefined;
+var _ow: *std.Io.Writer = undefined;
+
+fn _out( comptime fmt: []const u8, args: anytype ) void
+{
+	_ow.print( fmt, args ) catch {};
+}
+
+
+
+
+%%{
+	machine eofact;
+
+	action a1 {_out( "{s}", .{ "a1\n" } );
+}
+	action a2 {_out( "{s}", .{ "a2\n" } );
+}
+	action a3 {_out( "{s}", .{ "a3\n" } );
+}
+	action a4 {_out( "{s}", .{ "a4\n" } );
+}
+
+
+	main := (
+		'hello' @eof a1 %eof a2 '\n'? |
+		'there' @eof a3 %eof a4
+	);
+
+}%%
+
+
+
+%% write data;
+
+fn m( s: []const u8 ) void
+{
+	const data = s;
+	var p: i32 = 0;
+	var pe: i32 = @intCast( s.len );
+	var eof: i32 = @intCast( s.len );
+	var cs: i32 = 0;
+	var buffer: [1024]u8 = undefined;
+	var blen: usize = 0;
+
+	_ = &data; _ = &p; _ = &pe; _ = &eof; _ = &cs;
+	_ = &buffer; _ = &blen;
+
+	%% write init;
+	%% write exec;
+
+	if ( cs >= eofact_first_final ) {
+		_out( "ACCEPT\n", .{} );
+	}
+	else {
+		_out( "FAIL\n", .{} );
+	}
+}
+
+pub fn main() void
+{
+	var _w = std.Io.File.stdout().writer( _thr.io(), &_obuf );
+	_ow = &_w.interface;
+	defer _w.interface.flush() catch {};
+
+	m( "" );
+	m( "h" );
+	m( "hell" );
+	m( "hello" );
+	m( "hello\n" );
+	m( "t" );
+	m( "ther" );
+	m( "there" );
+	m( "friend" );
+}
+

--- a/test/trans.d/case/erract2_zig.rl
+++ b/test/trans.d/case/erract2_zig.rl
@@ -1,0 +1,96 @@
+//
+// @LANG: zig
+// @GENERATED: true
+//
+
+const std = @import("std");
+
+// The test harness diffs stdout; std.debug.print is stderr only.
+var _thr: std.Io.Threaded = .init_single_threaded;
+var _obuf: [4096]u8 = undefined;
+var _ow: *std.Io.Writer = undefined;
+
+fn _out( comptime fmt: []const u8, args: anytype ) void
+{
+	_ow.print( fmt, args ) catch {};
+}
+
+
+
+
+%%{
+	machine erract;
+
+	action err_start {_out( "{s}", .{ "err_start\n" } );
+}
+	action err_all {_out( "{s}", .{ "err_all\n" } );
+}
+	action err_middle {_out( "{s}", .{ "err_middle\n" } );
+}
+	action err_out {_out( "{s}", .{ "err_out\n" } );
+}
+
+	action eof_start {_out( "{s}", .{ "eof_start\n" } );
+}
+	action eof_all {_out( "{s}", .{ "eof_all\n" } );
+}
+	action eof_middle {_out( "{s}", .{ "eof_middle\n" } );
+}
+	action eof_out {_out( "{s}", .{ "eof_out\n" } );
+}
+
+	main := ( 'hello' 
+			>err err_start $err err_all <>err err_middle %err err_out
+			>eof eof_start $eof eof_all <>eof eof_middle %eof eof_out
+		) '\n';
+}%%
+
+
+
+%% write data;
+
+fn m( s: []const u8 ) void
+{
+	const data = s;
+	var p: i32 = 0;
+	var pe: i32 = @intCast( s.len );
+	var eof: i32 = @intCast( s.len );
+	var cs: i32 = 0;
+	var buffer: [1024]u8 = undefined;
+	var blen: usize = 0;
+
+	_ = &data; _ = &p; _ = &pe; _ = &eof; _ = &cs;
+	_ = &buffer; _ = &blen;
+
+	%% write init;
+	%% write exec;
+
+	if ( cs >= erract_first_final ) {
+		_out( "ACCEPT\n", .{} );
+	}
+	else {
+		_out( "FAIL\n", .{} );
+	}
+}
+
+pub fn main() void
+{
+	var _w = std.Io.File.stdout().writer( _thr.io(), &_obuf );
+	_ow = &_w.interface;
+	defer _w.interface.flush() catch {};
+
+	m( "" );
+	m( "h" );
+	m( "x" );
+	m( "he" );
+	m( "hx" );
+	m( "hel" );
+	m( "hex" );
+	m( "hell" );
+	m( "helx" );
+	m( "hello" );
+	m( "hellx" );
+	m( "hello\n" );
+	m( "hellox" );
+}
+

--- a/test/trans.d/case/goto1_zig.rl
+++ b/test/trans.d/case/goto1_zig.rl
@@ -1,0 +1,77 @@
+//
+// @LANG: zig
+// @GENERATED: true
+//
+
+const std = @import("std");
+
+// The test harness diffs stdout; std.debug.print is stderr only.
+var _thr: std.Io.Threaded = .init_single_threaded;
+var _obuf: [4096]u8 = undefined;
+var _ow: *std.Io.Writer = undefined;
+
+fn _out( comptime fmt: []const u8, args: anytype ) void
+{
+	_ow.print( fmt, args ) catch {};
+}
+
+var target: i32 = 0;
+
+%%{
+	machine goto1;
+
+	unused := 'unused';
+
+	one := 'one' @{_out( "{s}", .{ "one\n" } );
+target = fentry(main);
+fgoto *target;};
+
+	two := 'two' @{_out( "{s}", .{ "two\n" } );
+target = fentry(main);
+fgoto *target;};
+
+	main := 
+		'1' @{target = fentry(one);
+fgoto *target;}
+	|	'2' @{target = fentry(two);
+fgoto *target;}
+	|	'\n';
+}%%
+
+
+
+%% write data;
+
+fn m( s: []const u8 ) void
+{
+	const data = s;
+	var p: i32 = 0;
+	var pe: i32 = @intCast( s.len );
+	var eof: i32 = @intCast( s.len );
+	var cs: i32 = 0;
+	var buffer: [1024]u8 = undefined;
+	var blen: usize = 0;
+
+	_ = &data; _ = &p; _ = &pe; _ = &eof; _ = &cs;
+	_ = &buffer; _ = &blen;
+
+	%% write init;
+	%% write exec;
+
+	if ( cs >= goto1_first_final ) {
+		_out( "ACCEPT\n", .{} );
+	}
+	else {
+		_out( "FAIL\n", .{} );
+	}
+}
+
+pub fn main() void
+{
+	var _w = std.Io.File.stdout().writer( _thr.io(), &_obuf );
+	_ow = &_w.interface;
+	defer _w.interface.flush() catch {};
+
+	m( "1one2two1one\n" );
+}
+

--- a/test/trans.d/case/gotocallret1_zig.rl
+++ b/test/trans.d/case/gotocallret1_zig.rl
@@ -1,0 +1,123 @@
+//
+// @LANG: zig
+// @GENERATED: true
+//
+
+const std = @import("std");
+
+// The test harness diffs stdout; std.debug.print is stderr only.
+var _thr: std.Io.Threaded = .init_single_threaded;
+var _obuf: [4096]u8 = undefined;
+var _ow: *std.Io.Writer = undefined;
+
+fn _out( comptime fmt: []const u8, args: anytype ) void
+{
+	_ow.print( fmt, args ) catch {};
+}
+
+var comm: u8 = 0;
+var top: i32 = 0;
+var stack: [32]i32 = .{ 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 };
+
+%%{
+	machine GotoCallRet;
+
+	# A reference to a state in an unused action caused a segfault in 5.8. */
+	action unusedAction {fentry(garble_line);
+}
+
+	action err_garbling_line {_out( "{s}", .{ "error: garbling line\n" } );
+}
+	action goto_main {fgoto main;}
+	action recovery_failed {_out( "{s}", .{ "error: failed to recover\n" } );
+}
+
+	# Error machine, consumes to end of 
+	# line, then starts the main line over.
+	garble_line := ( (any-'\n')*'\n') 
+		>err_garbling_line
+		@goto_main
+		$/recovery_failed;
+
+	action hold_and_return {fhold;fret;}
+
+	# Look for a string of alphas or of digits, 
+	# on anything else, hold the character and return.
+	alp_comm := alpha+ $!hold_and_return;
+	dig_comm := digit+ $!hold_and_return;
+
+	# Choose which to machine to call into based on the command.
+	action comm_arg {if ( comm >= 'a' )
+{
+	fcall alp_comm;
+}
+else {
+	fcall dig_comm;
+}
+}
+
+	# Specifies command string. Note that the arg is left out.
+	command = (
+		[a-z0-9] @{comm = fc;
+} ' ' @comm_arg '\n'
+	) @{_out( "{s}", .{ "correct command\n" } );
+};
+
+	# Any number of commands. If there is an 
+	# error anywhere, garble the line.
+	main := command* $!{fhold;fgoto garble_line;}; 
+}%%
+
+
+
+%% write data;
+
+fn m( s: []const u8 ) void
+{
+	const data = s;
+	var p: i32 = 0;
+	var pe: i32 = @intCast( s.len );
+	var eof: i32 = @intCast( s.len );
+	var cs: i32 = 0;
+	var buffer: [1024]u8 = undefined;
+	var blen: usize = 0;
+
+	_ = &data; _ = &p; _ = &pe; _ = &eof; _ = &cs;
+	_ = &buffer; _ = &blen;
+
+	%% write init;
+	%% write exec;
+
+	if ( cs >= GotoCallRet_first_final ) {
+		_out( "ACCEPT\n", .{} );
+	}
+	else {
+		_out( "FAIL\n", .{} );
+	}
+}
+
+pub fn main() void
+{
+	var _w = std.Io.File.stdout().writer( _thr.io(), &_obuf );
+	_ow = &_w.interface;
+	defer _w.interface.flush() catch {};
+
+	m( "lkajsdf\n" );
+	m( "2134\n" );
+	m( "(\n" );
+	m( "\n" );
+	m( "*234234()0909 092 -234aslkf09`1 11\n" );
+	m( "1\n" );
+	m( "909\n" );
+	m( "1 a\n" );
+	m( "11 1\n" );
+	m( "a 1\n" );
+	m( "aa a\n" );
+	m( "1 1\n" );
+	m( "1 123456\n" );
+	m( "a a\n" );
+	m( "a abcdef\n" );
+	m( "h" );
+	m( "a aa1" );
+}
+

--- a/test/trans.d/case/gotocallret2_zig.rl
+++ b/test/trans.d/case/gotocallret2_zig.rl
@@ -1,0 +1,136 @@
+//
+// @LANG: zig
+// @GENERATED: true
+//
+
+const std = @import("std");
+
+// The test harness diffs stdout; std.debug.print is stderr only.
+var _thr: std.Io.Threaded = .init_single_threaded;
+var _obuf: [4096]u8 = undefined;
+var _ow: *std.Io.Writer = undefined;
+
+fn _out( comptime fmt: []const u8, args: anytype ) void
+{
+	_ow.print( fmt, args ) catch {};
+}
+
+var comm: u8 = 0;
+var top: i32 = 0;
+var stack: [32]i32 = .{ 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 };
+var ts: i32 = 0;
+var te: i32 = 0;
+var act: i32 = 0;
+var val: i32 = 0;
+
+%%{
+	machine GotoCallRet;
+
+	sp = ' ';
+
+	handle := any @{_out( "{s}", .{ "handle " } );
+fhold;if ( val == 1 )
+{
+	fnext *fentry(one);
+}
+if ( val == 2 )
+{
+	fnext *fentry(two);
+}
+if ( val == 3 )
+{
+	fnext main;
+}
+};
+
+	one := |*
+		'{' => {_out( "{s}", .{ "{ " } );
+fcall *fentry(one);};
+		"[" => {_out( "{s}", .{ "[ " } );
+fcall *fentry(two);};
+		"}" sp* => {_out( "{s}", .{ "} " } );
+fret;};
+		[a-z]+ => {_out( "{s}", .{ "word " } );
+val = 1;
+fgoto *fentry(handle);};
+		' ' => {_out( "{s}", .{ "space " } );
+};
+	*|;
+
+	two := |*
+		'{' => {_out( "{s}", .{ "{ " } );
+fcall *fentry(one);};
+		"[" => {_out( "{s}", .{ "[ " } );
+fcall *fentry(two);};
+		']' sp* => {_out( "{s}", .{ "] " } );
+fret;};
+		[a-z]+ => {_out( "{s}", .{ "word " } );
+val = 2;
+fgoto *fentry(handle);};
+		' ' => {_out( "{s}", .{ "space " } );
+};
+	*|;
+
+	main := |* 
+		'{' => {_out( "{s}", .{ "{ " } );
+fcall one;};
+		"[" => {_out( "{s}", .{ "[ " } );
+fcall two;};
+		[a-z]+ => {_out( "{s}", .{ "word " } );
+val = 3;
+fgoto handle;};
+		[a-z] ' foil' => {_out( "{s}", .{ "this is the foil" } );
+};
+		' ' => {_out( "{s}", .{ "space " } );
+};
+		'\n';
+	*|;
+}%%
+
+
+
+%% write data;
+
+fn m( s: []const u8 ) void
+{
+	const data = s;
+	var p: i32 = 0;
+	var pe: i32 = @intCast( s.len );
+	var eof: i32 = @intCast( s.len );
+	var cs: i32 = 0;
+	var buffer: [1024]u8 = undefined;
+	var blen: usize = 0;
+
+	_ = &data; _ = &p; _ = &pe; _ = &eof; _ = &cs;
+	_ = &buffer; _ = &blen;
+
+	%% write init;
+	%% write exec;
+
+	if ( cs >= GotoCallRet_first_final ) {
+		_out( "ACCEPT\n", .{} );
+	}
+	else {
+		_out( "FAIL\n", .{} );
+	}
+}
+
+pub fn main() void
+{
+	var _w = std.Io.File.stdout().writer( _thr.io(), &_obuf );
+	_ow = &_w.interface;
+	defer _w.interface.flush() catch {};
+
+	m( "{a{b[c d]d}c}\n" );
+	m( "[a{b[c d]d}c}\n" );
+	m( "[a[b]c]d{ef{g{h}i}j}l\n" );
+	m( "{{[]}}\n" );
+	m( "a b c\n" );
+	m( "{a b c}\n" );
+	m( "[a b c]\n" );
+	m( "{]\n" );
+	m( "{{}\n" );
+	m( "[[[[[[]]]]]]\n" );
+	m( "[[[[[[]]}]]]\n" );
+}
+

--- a/test/trans.d/case/gotocallret3_zig.rl
+++ b/test/trans.d/case/gotocallret3_zig.rl
@@ -1,0 +1,124 @@
+//
+// @LANG: zig
+// @GENERATED: true
+//
+
+const std = @import("std");
+
+// The test harness diffs stdout; std.debug.print is stderr only.
+var _thr: std.Io.Threaded = .init_single_threaded;
+var _obuf: [4096]u8 = undefined;
+var _ow: *std.Io.Writer = undefined;
+
+fn _out( comptime fmt: []const u8, args: anytype ) void
+{
+	_ow.print( fmt, args ) catch {};
+}
+
+var comm: u8 = 0;
+var top: i32 = 0;
+var stack: [32]i32 = .{ 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 };
+
+%%{
+	machine gotocallret;
+
+	# A reference to a state in an unused action caused a segfault in 5.8. */
+	action unusedAction {fentry(garble_line);
+}
+
+	action err_garbling_line {_out( "{s}", .{ "error: garbling line\n" } );
+}
+	action goto_main {fnext main;}
+	action recovery_failed {_out( "{s}", .{ "error: failed to recover\n" } );
+}
+
+	# Error machine, consumes to end of 
+	# line, then starts the main line over.
+	garble_line := ( (any-'\n')*'\n') 
+		>err_garbling_line
+		@goto_main
+		$/recovery_failed;
+
+	action hold_and_return {fhold;fnret;}
+
+	# Look for a string of alphas or of digits, 
+	# on anything else, hold the character and return.
+	alp_comm := alpha+ $!hold_and_return;
+	dig_comm := digit+ $!hold_and_return;
+
+	# Choose which to machine to call into based on the command.
+	action comm_arg {if ( comm >= 97 )
+{
+	fncall alp_comm;
+}
+else {
+	fncall dig_comm;
+}
+}
+
+	# Specifies command string. Note that the arg is left out.
+	command = (
+		[a-z0-9] @{comm = fc;
+} ' ' @comm_arg @{_out( "{s}", .{ "prints\n" } );
+} '\n'
+	) @{_out( "{s}", .{ "correct command\n" } );
+};
+
+	# Any number of commands. If there is an 
+	# error anywhere, garble the line.
+	main := command* $!{fhold;fnext garble_line;}; 
+}%%
+
+
+
+%% write data;
+
+fn m( s: []const u8 ) void
+{
+	const data = s;
+	var p: i32 = 0;
+	var pe: i32 = @intCast( s.len );
+	var eof: i32 = @intCast( s.len );
+	var cs: i32 = 0;
+	var buffer: [1024]u8 = undefined;
+	var blen: usize = 0;
+
+	_ = &data; _ = &p; _ = &pe; _ = &eof; _ = &cs;
+	_ = &buffer; _ = &blen;
+
+	%% write init;
+	%% write exec;
+
+	if ( cs >= gotocallret_first_final ) {
+		_out( "ACCEPT\n", .{} );
+	}
+	else {
+		_out( "FAIL\n", .{} );
+	}
+}
+
+pub fn main() void
+{
+	var _w = std.Io.File.stdout().writer( _thr.io(), &_obuf );
+	_ow = &_w.interface;
+	defer _w.interface.flush() catch {};
+
+	m( "lkajsdf\n" );
+	m( "2134\n" );
+	m( "(\n" );
+	m( "\n" );
+	m( "*234234()0909 092 -234aslkf09`1 11\n" );
+	m( "1\n" );
+	m( "909\n" );
+	m( "1 a\n" );
+	m( "11 1\n" );
+	m( "a 1\n" );
+	m( "aa a\n" );
+	m( "1 1\n" );
+	m( "1 123456\n" );
+	m( "a a\n" );
+	m( "a abcdef\n" );
+	m( "h" );
+	m( "a aa1" );
+}
+

--- a/test/trans.d/case/ncall1_zig.rl
+++ b/test/trans.d/case/ncall1_zig.rl
@@ -1,0 +1,78 @@
+//
+// @LANG: zig
+// @GENERATED: true
+//
+
+const std = @import("std");
+
+// The test harness diffs stdout; std.debug.print is stderr only.
+var _thr: std.Io.Threaded = .init_single_threaded;
+var _obuf: [4096]u8 = undefined;
+var _ow: *std.Io.Writer = undefined;
+
+fn _out( comptime fmt: []const u8, args: anytype ) void
+{
+	_ow.print( fmt, args ) catch {};
+}
+
+var top: i32 = 0;
+var stack: [32]i32 = .{ 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 };
+var target: i32 = 0;
+
+%%{
+	machine ncall1;
+
+	unused := 'unused';
+
+	one := 'one' @{_out( "{s}", .{ "one\n" } );
+fnret;};
+
+	two := 'two' @{_out( "{s}", .{ "two\n" } );
+fnret;};
+
+	main := (
+			'1' @{target = fentry(one);
+fncall *target;}
+		|	'2' @{target = fentry(two);
+fncall *target;}
+		|	'\n'
+	)*;
+}%%
+
+
+
+%% write data;
+
+fn m( s: []const u8 ) void
+{
+	const data = s;
+	var p: i32 = 0;
+	var pe: i32 = @intCast( s.len );
+	var eof: i32 = @intCast( s.len );
+	var cs: i32 = 0;
+	var buffer: [1024]u8 = undefined;
+	var blen: usize = 0;
+
+	_ = &data; _ = &p; _ = &pe; _ = &eof; _ = &cs;
+	_ = &buffer; _ = &blen;
+
+	%% write init;
+	%% write exec;
+
+	if ( cs >= ncall1_first_final ) {
+		_out( "ACCEPT\n", .{} );
+	}
+	else {
+		_out( "FAIL\n", .{} );
+	}
+}
+
+pub fn main() void
+{
+	var _w = std.Io.File.stdout().writer( _thr.io(), &_obuf );
+	_ow = &_w.interface;
+	defer _w.interface.flush() catch {};
+
+	m( "1one2two1one\n" );
+}
+

--- a/test/trans.d/case/next1_zig.rl
+++ b/test/trans.d/case/next1_zig.rl
@@ -1,0 +1,77 @@
+//
+// @LANG: zig
+// @GENERATED: true
+//
+
+const std = @import("std");
+
+// The test harness diffs stdout; std.debug.print is stderr only.
+var _thr: std.Io.Threaded = .init_single_threaded;
+var _obuf: [4096]u8 = undefined;
+var _ow: *std.Io.Writer = undefined;
+
+fn _out( comptime fmt: []const u8, args: anytype ) void
+{
+	_ow.print( fmt, args ) catch {};
+}
+
+var target: i32 = 0;
+
+%%{
+	machine next1;
+
+	unused := 'unused';
+
+	one := 'one' @{_out( "{s}", .{ "one\n" } );
+target = fentry(main);
+fnext *target;};
+
+	two := 'two' @{_out( "{s}", .{ "two\n" } );
+target = fentry(main);
+fnext *target;};
+
+	main := 
+		'1' @{target = fentry(one);
+fnext *target;}
+	|	'2' @{target = fentry(two);
+fnext *target;}
+	|	'\n';
+}%%
+
+
+
+%% write data;
+
+fn m( s: []const u8 ) void
+{
+	const data = s;
+	var p: i32 = 0;
+	var pe: i32 = @intCast( s.len );
+	var eof: i32 = @intCast( s.len );
+	var cs: i32 = 0;
+	var buffer: [1024]u8 = undefined;
+	var blen: usize = 0;
+
+	_ = &data; _ = &p; _ = &pe; _ = &eof; _ = &cs;
+	_ = &buffer; _ = &blen;
+
+	%% write init;
+	%% write exec;
+
+	if ( cs >= next1_first_final ) {
+		_out( "ACCEPT\n", .{} );
+	}
+	else {
+		_out( "FAIL\n", .{} );
+	}
+}
+
+pub fn main() void
+{
+	var _w = std.Io.File.stdout().writer( _thr.io(), &_obuf );
+	_ow = &_w.interface;
+	defer _w.interface.flush() catch {};
+
+	m( "1one2two1one\n" );
+}
+

--- a/test/trans.d/case/next2_zig.rl
+++ b/test/trans.d/case/next2_zig.rl
@@ -1,0 +1,96 @@
+//
+// @LANG: zig
+// @GENERATED: true
+//
+
+const std = @import("std");
+
+// The test harness diffs stdout; std.debug.print is stderr only.
+var _thr: std.Io.Threaded = .init_single_threaded;
+var _obuf: [4096]u8 = undefined;
+var _ow: *std.Io.Writer = undefined;
+
+fn _out( comptime fmt: []const u8, args: anytype ) void
+{
+	_ow.print( fmt, args ) catch {};
+}
+
+var target: i32 = 0;
+var last: i32 = 0;
+
+%%{
+	machine next2;
+
+	unused := 'unused';
+
+	one := 'one' @{_out( "{s}", .{ "one\n" } );
+target = fentry(main);
+fnext *target;};
+
+	two := 'two' @{_out( "{s}", .{ "two\n" } );
+target = fentry(main);
+fnext *target;};
+
+	three := 'three' @{_out( "{s}", .{ "three\n" } );
+target = fentry(main);
+fnext *target;};
+
+	main :=  (
+		'1' @{target = fentry(one);
+fnext *target;last = 1;
+} |
+
+		'2' @{target = fentry(two);
+fnext *target;last = 2;
+} |
+
+		# This one is conditional based on the last.
+		'3' @{if ( last == 2 )
+{
+	target = fentry(three);
+fnext *target;
+}
+last = 3;
+} 'x' |
+
+		'\n'
+	)*;
+}%%
+
+
+
+%% write data;
+
+fn m( s: []const u8 ) void
+{
+	const data = s;
+	var p: i32 = 0;
+	var pe: i32 = @intCast( s.len );
+	var eof: i32 = @intCast( s.len );
+	var cs: i32 = 0;
+	var buffer: [1024]u8 = undefined;
+	var blen: usize = 0;
+
+	_ = &data; _ = &p; _ = &pe; _ = &eof; _ = &cs;
+	_ = &buffer; _ = &blen;
+
+	%% write init;
+	%% write exec;
+
+	if ( cs >= next2_first_final ) {
+		_out( "ACCEPT\n", .{} );
+	}
+	else {
+		_out( "FAIL\n", .{} );
+	}
+}
+
+pub fn main() void
+{
+	var _w = std.Io.File.stdout().writer( _thr.io(), &_obuf );
+	_ow = &_w.interface;
+	defer _w.interface.flush() catch {};
+
+	m( "1one3x2two3three\n" );
+}
+

--- a/test/trans.d/case/patact_zig.rl
+++ b/test/trans.d/case/patact_zig.rl
@@ -1,0 +1,121 @@
+//
+// @LANG: zig
+// @GENERATED: true
+//
+
+const std = @import("std");
+
+// The test harness diffs stdout; std.debug.print is stderr only.
+var _thr: std.Io.Threaded = .init_single_threaded;
+var _obuf: [4096]u8 = undefined;
+var _ow: *std.Io.Writer = undefined;
+
+fn _out( comptime fmt: []const u8, args: anytype ) void
+{
+	_ow.print( fmt, args ) catch {};
+}
+
+var comm: u8 = 0;
+var top: i32 = 0;
+var stack: [32]i32 = .{ 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 };
+var ts: i32 = 0;
+var te: i32 = 0;
+var act: i32 = 0;
+var value: i32 = 0;
+
+%%{
+	machine patact;
+
+	other := |* 
+		[a-z]+ => {_out( "{s}", .{ "word\n" } );
+};
+		[0-9]+ => {_out( "{s}", .{ "num\n" } );
+};
+		[\n ] => {_out( "{s}", .{ "space\n" } );
+};
+	*|;
+
+	exec_test := |* 
+		[a-z]+ => {_out( "{s}", .{ "word (w/lbh)\n" } );
+fexec te-1;fgoto other;};
+		[a-z]+ ' foil' => {_out( "{s}", .{ "word (c/lbh)\n" } );
+};
+		[\n ] => {_out( "{s}", .{ "space\n" } );
+};
+		'22' => {_out( "{s}", .{ "num (w/switch)\n" } );
+};
+		[0-9]+ => {_out( "{s}", .{ "num (w/switch)\n" } );
+fexec te-1;fgoto other;};
+		[0-9]+ ' foil' => {_out( "{s}", .{ "num (c/switch)\n" } );
+};
+		'!';# => { print_str "immdiate\n"; fgoto exec_test; };
+	*|;
+
+	semi := |* 
+		';' => {_out( "{s}", .{ "in semi\n" } );
+fgoto main;};
+	*|;
+
+	main := |* 
+		[a-z]+ => {_out( "{s}", .{ "word (w/lbh)\n" } );
+fhold;fgoto other;};
+		[a-z]+ ' foil' => {_out( "{s}", .{ "word (c/lbh)\n" } );
+};
+		[\n ] => {_out( "{s}", .{ "space\n" } );
+};
+		'22' => {_out( "{s}", .{ "num (w/switch)\n" } );
+};
+		[0-9]+ => {_out( "{s}", .{ "num (w/switch)\n" } );
+fhold;fgoto other;};
+		[0-9]+ ' foil' => {_out( "{s}", .{ "num (c/switch)\n" } );
+};
+		';' => {_out( "{s}", .{ "going to semi\n" } );
+fhold;fgoto semi;};
+		'!' => {_out( "{s}", .{ "immdiate\n" } );
+fgoto exec_test;};
+	*|;
+}%%
+
+
+
+%% write data;
+
+fn m( s: []const u8 ) void
+{
+	const data = s;
+	var p: i32 = 0;
+	var pe: i32 = @intCast( s.len );
+	var eof: i32 = @intCast( s.len );
+	var cs: i32 = 0;
+	var buffer: [1024]u8 = undefined;
+	var blen: usize = 0;
+
+	_ = &data; _ = &p; _ = &pe; _ = &eof; _ = &cs;
+	_ = &buffer; _ = &blen;
+
+	%% write init;
+	%% write exec;
+
+	if ( cs >= patact_first_final ) {
+		_out( "ACCEPT\n", .{} );
+	}
+	else {
+		_out( "FAIL\n", .{} );
+	}
+}
+
+pub fn main() void
+{
+	var _w = std.Io.File.stdout().writer( _thr.io(), &_obuf );
+	_ow = &_w.interface;
+	defer _w.interface.flush() catch {};
+
+	m( "abcd foix\n" );
+	m( "abcd\nanother\n" );
+	m( "123 foix\n" );
+	m( "!abcd foix\n" );
+	m( "!abcd\nanother\n" );
+	m( "!123 foix\n" );
+	m( ";" );
+}
+

--- a/test/trans.d/case/rangei_zig.rl
+++ b/test/trans.d/case/rangei_zig.rl
@@ -1,0 +1,73 @@
+//
+// @LANG: zig
+// @GENERATED: true
+//
+
+const std = @import("std");
+
+// The test harness diffs stdout; std.debug.print is stderr only.
+var _thr: std.Io.Threaded = .init_single_threaded;
+var _obuf: [4096]u8 = undefined;
+var _ow: *std.Io.Writer = undefined;
+
+fn _out( comptime fmt: []const u8, args: anytype ) void
+{
+	_ow.print( fmt, args ) catch {};
+}
+
+
+
+%%{
+	machine rangei;
+
+	main := 
+		'a' ../i 'z' .
+		'A' ../i 'Z' .
+		60 ../i 93 .
+		94 ../i 125 .
+		86 ../i 101 .
+		60 ../i 125
+		'';
+}%%
+
+
+
+%% write data;
+
+fn m( s: []const u8 ) void
+{
+	const data = s;
+	var p: i32 = 0;
+	var pe: i32 = @intCast( s.len );
+	var eof: i32 = @intCast( s.len );
+	var cs: i32 = 0;
+	var buffer: [1024]u8 = undefined;
+	var blen: usize = 0;
+
+	_ = &data; _ = &p; _ = &pe; _ = &eof; _ = &cs;
+	_ = &buffer; _ = &blen;
+
+	%% write init;
+	%% write exec;
+
+	if ( cs >= rangei_first_final ) {
+		_out( "ACCEPT\n", .{} );
+	}
+	else {
+		_out( "FAIL\n", .{} );
+	}
+}
+
+pub fn main() void
+{
+	var _w = std.Io.File.stdout().writer( _thr.io(), &_obuf );
+	_ow = &_w.interface;
+	defer _w.interface.flush() catch {};
+
+	m( "AaBbAa" );
+	m( "Aa`bAa" );
+	m( "AaB@Aa" );
+	m( "AaBbMa" );
+	m( "AaBbma" );
+}
+

--- a/test/trans.d/case/scan1_zig.rl
+++ b/test/trans.d/case/scan1_zig.rl
@@ -1,0 +1,115 @@
+//
+// @LANG: zig
+// @GENERATED: true
+//
+
+const std = @import("std");
+
+// The test harness diffs stdout; std.debug.print is stderr only.
+var _thr: std.Io.Threaded = .init_single_threaded;
+var _obuf: [4096]u8 = undefined;
+var _ow: *std.Io.Writer = undefined;
+
+fn _out( comptime fmt: []const u8, args: anytype ) void
+{
+	_ow.print( fmt, args ) catch {};
+}
+
+var ts: i32 = 0;
+var te: i32 = 0;
+var act: i32 = 0;
+var token: i32 = 0;
+
+%%{
+	machine scanner;
+
+	# Warning: changing the patterns or the input string will affect the
+	# coverage of the scanner action types.
+	main := |*
+		'a' => {_out( "{s}", .{ "on last     " } );
+if ( p + 1 == te )
+{
+	_out( "{s}", .{ "yes" } );
+
+}
+_out( "{s}", .{ "\n" } );
+};
+
+		'b'+ => {_out( "{s}", .{ "on next     " } );
+if ( p + 1 == te )
+{
+	_out( "{s}", .{ "yes" } );
+
+}
+_out( "{s}", .{ "\n" } );
+};
+
+		'c1' 'dxxx'? => {_out( "{s}", .{ "on lag      " } );
+if ( p + 1 == te )
+{
+	_out( "{s}", .{ "yes" } );
+
+}
+_out( "{s}", .{ "\n" } );
+};
+
+		'd1' => {_out( "{s}", .{ "lm switch1  " } );
+if ( p + 1 == te )
+{
+	_out( "{s}", .{ "yes" } );
+
+}
+_out( "{s}", .{ "\n" } );
+};
+		'd2' => {_out( "{s}", .{ "lm switch2  " } );
+if ( p + 1 == te )
+{
+	_out( "{s}", .{ "yes" } );
+
+}
+_out( "{s}", .{ "\n" } );
+};
+
+		[d0-9]+ '.';
+
+		'\n';
+	*|;
+}%%
+
+
+
+%% write data;
+
+fn m( s: []const u8 ) void
+{
+	const data = s;
+	var p: i32 = 0;
+	var pe: i32 = @intCast( s.len );
+	var eof: i32 = @intCast( s.len );
+	var cs: i32 = 0;
+	var buffer: [1024]u8 = undefined;
+	var blen: usize = 0;
+
+	_ = &data; _ = &p; _ = &pe; _ = &eof; _ = &cs;
+	_ = &buffer; _ = &blen;
+
+	%% write init;
+	%% write exec;
+
+	if ( cs >= scanner_first_final ) {
+		_out( "ACCEPT\n", .{} );
+	}
+	else {
+		_out( "FAIL\n", .{} );
+	}
+}
+
+pub fn main() void
+{
+	var _w = std.Io.File.stdout().writer( _thr.io(), &_obuf );
+	_ow = &_w.interface;
+	defer _w.interface.flush() catch {};
+
+	m( "abbc1d1d2\n" );
+}
+

--- a/test/trans.d/case/scan2_zig.rl
+++ b/test/trans.d/case/scan2_zig.rl
@@ -1,0 +1,76 @@
+//
+// @LANG: zig
+// @GENERATED: true
+//
+
+const std = @import("std");
+
+// The test harness diffs stdout; std.debug.print is stderr only.
+var _thr: std.Io.Threaded = .init_single_threaded;
+var _obuf: [4096]u8 = undefined;
+var _ow: *std.Io.Writer = undefined;
+
+fn _out( comptime fmt: []const u8, args: anytype ) void
+{
+	_ow.print( fmt, args ) catch {};
+}
+
+var ts: i32 = 0;
+var te: i32 = 0;
+var act: i32 = 0;
+var token: i32 = 0;
+
+%%{
+	machine scanner;
+
+	# Warning: changing the patterns or the input string will affect the
+	# coverage of the scanner action types.
+	main := |*
+        'a' => {_out( "{s}", .{ "pat1\n" } );
+};
+
+        [ab]+ . 'c' => {_out( "{s}", .{ "pat2\n" } );
+};
+
+        any => {_out( "{s}", .{ "any\n" } );
+};
+	*|;
+}%%
+
+
+
+%% write data;
+
+fn m( s: []const u8 ) void
+{
+	const data = s;
+	var p: i32 = 0;
+	var pe: i32 = @intCast( s.len );
+	var eof: i32 = @intCast( s.len );
+	var cs: i32 = 0;
+	var buffer: [1024]u8 = undefined;
+	var blen: usize = 0;
+
+	_ = &data; _ = &p; _ = &pe; _ = &eof; _ = &cs;
+	_ = &buffer; _ = &blen;
+
+	%% write init;
+	%% write exec;
+
+	if ( cs >= scanner_first_final ) {
+		_out( "ACCEPT\n", .{} );
+	}
+	else {
+		_out( "FAIL\n", .{} );
+	}
+}
+
+pub fn main() void
+{
+	var _w = std.Io.File.stdout().writer( _thr.io(), &_obuf );
+	_ow = &_w.interface;
+	defer _w.interface.flush() catch {};
+
+	m( "a" );
+}
+

--- a/test/trans.d/case/scan3_zig.rl
+++ b/test/trans.d/case/scan3_zig.rl
@@ -1,0 +1,74 @@
+//
+// @LANG: zig
+// @GENERATED: true
+//
+
+const std = @import("std");
+
+// The test harness diffs stdout; std.debug.print is stderr only.
+var _thr: std.Io.Threaded = .init_single_threaded;
+var _obuf: [4096]u8 = undefined;
+var _ow: *std.Io.Writer = undefined;
+
+fn _out( comptime fmt: []const u8, args: anytype ) void
+{
+	_ow.print( fmt, args ) catch {};
+}
+
+var ts: i32 = 0;
+var te: i32 = 0;
+var act: i32 = 0;
+var token: i32 = 0;
+
+%%{
+	machine scanner;
+
+	# Warning: changing the patterns or the input string will affect the
+	# coverage of the scanner action types.
+	main := |*
+		'a' => {_out( "{s}", .{ "pat1\n" } );
+};
+		'b' => {_out( "{s}", .{ "pat2\n" } );
+};
+        [ab] any*  => {_out( "{s}", .{ "pat3\n" } );
+};
+	*|;
+}%%
+
+
+
+%% write data;
+
+fn m( s: []const u8 ) void
+{
+	const data = s;
+	var p: i32 = 0;
+	var pe: i32 = @intCast( s.len );
+	var eof: i32 = @intCast( s.len );
+	var cs: i32 = 0;
+	var buffer: [1024]u8 = undefined;
+	var blen: usize = 0;
+
+	_ = &data; _ = &p; _ = &pe; _ = &eof; _ = &cs;
+	_ = &buffer; _ = &blen;
+
+	%% write init;
+	%% write exec;
+
+	if ( cs >= scanner_first_final ) {
+		_out( "ACCEPT\n", .{} );
+	}
+	else {
+		_out( "FAIL\n", .{} );
+	}
+}
+
+pub fn main() void
+{
+	var _w = std.Io.File.stdout().writer( _thr.io(), &_obuf );
+	_ow = &_w.interface;
+	defer _w.interface.flush() catch {};
+
+	m( "ab89" );
+}
+

--- a/test/trans.d/case/scan4_zig.rl
+++ b/test/trans.d/case/scan4_zig.rl
@@ -1,0 +1,75 @@
+//
+// @LANG: zig
+// @GENERATED: true
+//
+
+const std = @import("std");
+
+// The test harness diffs stdout; std.debug.print is stderr only.
+var _thr: std.Io.Threaded = .init_single_threaded;
+var _obuf: [4096]u8 = undefined;
+var _ow: *std.Io.Writer = undefined;
+
+fn _out( comptime fmt: []const u8, args: anytype ) void
+{
+	_ow.print( fmt, args ) catch {};
+}
+
+var ts: i32 = 0;
+var te: i32 = 0;
+var act: i32 = 0;
+var token: i32 = 0;
+
+%%{
+	machine scanner;
+
+	# Warning: changing the patterns or the input string will affect the
+	# coverage of the scanner action types.
+	main := |*
+	  'a' => {_out( "{s}", .{ "pat1\n" } );
+};
+
+	  [ab]+ . 'c' => {_out( "{s}", .{ "pat2\n" } );
+};
+
+	  any;
+	*|;
+}%%
+
+
+
+%% write data;
+
+fn m( s: []const u8 ) void
+{
+	const data = s;
+	var p: i32 = 0;
+	var pe: i32 = @intCast( s.len );
+	var eof: i32 = @intCast( s.len );
+	var cs: i32 = 0;
+	var buffer: [1024]u8 = undefined;
+	var blen: usize = 0;
+
+	_ = &data; _ = &p; _ = &pe; _ = &eof; _ = &cs;
+	_ = &buffer; _ = &blen;
+
+	%% write init;
+	%% write exec;
+
+	if ( cs >= scanner_first_final ) {
+		_out( "ACCEPT\n", .{} );
+	}
+	else {
+		_out( "FAIL\n", .{} );
+	}
+}
+
+pub fn main() void
+{
+	var _w = std.Io.File.stdout().writer( _thr.io(), &_obuf );
+	_ow = &_w.interface;
+	defer _w.interface.flush() catch {};
+
+	m( "ba a" );
+}
+

--- a/test/trans.d/case/stateact1_zig.rl
+++ b/test/trans.d/case/stateact1_zig.rl
@@ -1,0 +1,89 @@
+//
+// @LANG: zig
+// @GENERATED: true
+//
+
+const std = @import("std");
+
+// The test harness diffs stdout; std.debug.print is stderr only.
+var _thr: std.Io.Threaded = .init_single_threaded;
+var _obuf: [4096]u8 = undefined;
+var _ow: *std.Io.Writer = undefined;
+
+fn _out( comptime fmt: []const u8, args: anytype ) void
+{
+	_ow.print( fmt, args ) catch {};
+}
+
+
+
+
+%%{
+	machine state_act;
+
+	action a1 {_out( "{s}", .{ "a1\n" } );
+}
+	action a2 {_out( "{s}", .{ "a2\n" } );
+}
+	action b1 {_out( "{s}", .{ "b1\n" } );
+}
+	action b2 {_out( "{s}", .{ "b2\n" } );
+}
+	action c1 {_out( "{s}", .{ "c1\n" } );
+}
+	action c2 {_out( "{s}", .{ "c2\n" } );
+}
+	action next_again {fnext again;}
+
+	hi = 'hi';
+	line = again: 
+			hi 
+				>to b1 
+				>from b2 
+			'\n' 
+				>to c1 
+				>from c2 
+				@next_again;
+		 
+	main := line*
+			>to a1 
+			>from a2;
+}%%
+
+
+
+%% write data;
+
+fn m( s: []const u8 ) void
+{
+	const data = s;
+	var p: i32 = 0;
+	var pe: i32 = @intCast( s.len );
+	var eof: i32 = @intCast( s.len );
+	var cs: i32 = 0;
+	var buffer: [1024]u8 = undefined;
+	var blen: usize = 0;
+
+	_ = &data; _ = &p; _ = &pe; _ = &eof; _ = &cs;
+	_ = &buffer; _ = &blen;
+
+	%% write init;
+	%% write exec;
+
+	if ( cs >= state_act_first_final ) {
+		_out( "ACCEPT\n", .{} );
+	}
+	else {
+		_out( "FAIL\n", .{} );
+	}
+}
+
+pub fn main() void
+{
+	var _w = std.Io.File.stdout().writer( _thr.io(), &_obuf );
+	_ow = &_w.interface;
+	defer _w.interface.flush() catch {};
+
+	m( "hi\nhi\n" );
+}
+

--- a/test/trans.d/case/targs1_zig.rl
+++ b/test/trans.d/case/targs1_zig.rl
@@ -1,0 +1,76 @@
+//
+// @LANG: zig
+// @GENERATED: true
+//
+
+const std = @import("std");
+
+// The test harness diffs stdout; std.debug.print is stderr only.
+var _thr: std.Io.Threaded = .init_single_threaded;
+var _obuf: [4096]u8 = undefined;
+var _ow: *std.Io.Writer = undefined;
+
+fn _out( comptime fmt: []const u8, args: anytype ) void
+{
+	_ow.print( fmt, args ) catch {};
+}
+
+var return_to: i32 = 0;
+
+%%{
+	machine targs1;
+
+	unused := 'unused';
+
+	one := 'one' @{_out( "{s}", .{ "one\n" } );
+fnext *return_to;};
+
+	two := 'two' @{_out( "{s}", .{ "two\n" } );
+fnext *return_to;};
+
+	main := (
+			'1' @{return_to = ftargs;
+fnext one;}
+		|	'2' @{return_to = ftargs;
+fnext two;}
+		|	'\n'
+	)*;
+}%%
+
+
+
+%% write data;
+
+fn m( s: []const u8 ) void
+{
+	const data = s;
+	var p: i32 = 0;
+	var pe: i32 = @intCast( s.len );
+	var eof: i32 = @intCast( s.len );
+	var cs: i32 = 0;
+	var buffer: [1024]u8 = undefined;
+	var blen: usize = 0;
+
+	_ = &data; _ = &p; _ = &pe; _ = &eof; _ = &cs;
+	_ = &buffer; _ = &blen;
+
+	%% write init;
+	%% write exec;
+
+	if ( cs >= targs1_first_final ) {
+		_out( "ACCEPT\n", .{} );
+	}
+	else {
+		_out( "FAIL\n", .{} );
+	}
+}
+
+pub fn main() void
+{
+	var _w = std.Io.File.stdout().writer( _thr.io(), &_obuf );
+	_ow = &_w.interface;
+	defer _w.interface.flush() catch {};
+
+	m( "1one2two1one\n" );
+}
+

--- a/test/trans.d/case/zlen1_zig.rl
+++ b/test/trans.d/case/zlen1_zig.rl
@@ -1,0 +1,63 @@
+//
+// @LANG: zig
+// @GENERATED: true
+//
+
+const std = @import("std");
+
+// The test harness diffs stdout; std.debug.print is stderr only.
+var _thr: std.Io.Threaded = .init_single_threaded;
+var _obuf: [4096]u8 = undefined;
+var _ow: *std.Io.Writer = undefined;
+
+fn _out( comptime fmt: []const u8, args: anytype ) void
+{
+	_ow.print( fmt, args ) catch {};
+}
+
+
+
+
+%%{
+	machine zlen1;
+	main := zlen;
+}%%
+
+
+
+%% write data;
+
+fn m( s: []const u8 ) void
+{
+	const data = s;
+	var p: i32 = 0;
+	var pe: i32 = @intCast( s.len );
+	var eof: i32 = @intCast( s.len );
+	var cs: i32 = 0;
+	var buffer: [1024]u8 = undefined;
+	var blen: usize = 0;
+
+	_ = &data; _ = &p; _ = &pe; _ = &eof; _ = &cs;
+	_ = &buffer; _ = &blen;
+
+	%% write init;
+	%% write exec;
+
+	if ( cs >= zlen1_first_final ) {
+		_out( "ACCEPT\n", .{} );
+	}
+	else {
+		_out( "FAIL\n", .{} );
+	}
+}
+
+pub fn main() void
+{
+	var _w = std.Io.File.stdout().writer( _thr.io(), &_obuf );
+	_ow = &_w.interface;
+	defer _w.interface.flush() catch {};
+
+	m( "" );
+	m( "x" );
+}
+

--- a/test/trans.d/gentests
+++ b/test/trans.d/gentests
@@ -3,7 +3,7 @@
 
 . ../subject.sh
 
-langs='asm crack c cs d go java julia ocaml'
+langs='asm crack c cs d go java julia ocaml zig'
 
 mkdir -p working
 

--- a/test/trans.d/trans-zig.lm
+++ b/test/trans.d/trans-zig.lm
@@ -28,11 +28,11 @@ int factor( Factor: indep::factor )
 	}
 	elsif match Factor ['true']
 	{
-		send Out 'true'
+		send Out '1'
 	}
 	elsif match Factor ['false']
 	{
-		send Out 'false'
+		send Out '0'
 	}
 	elsif match Factor [`buffer]
 	{
@@ -59,7 +59,7 @@ void type( Type: indep::type )
 	}
 	case [`bool]
 	{
-		send Out "bool"
+		send Out "i32"
 	}
 	case [`char]
 	{
@@ -115,8 +115,6 @@ void array_init( Size: int, Zero: str )
 int var_decl( VarDecl: indep::var_decl )
 {
 	Zero: str = '0'
-	if match VarDecl.type [`bool]
-		Zero = 'false'
 
 	if VarDecl.opt_arr.expr {
 		send Out
@@ -173,7 +171,7 @@ int print_stmt( Stmt: indep::print_stmt )
 		send Out
 			"_out( \"{d}\", .{ [expr(Stmt.expr)] } );
 	}
-	case [`print_buf `;]
+	case [`print_buf E1: expr `, E2: expr `;]
 	{
 		send Out
 			"_out( \"{s}\", .{ buffer\[0..blen\] } );
@@ -309,7 +307,7 @@ void zig( Output: stream )
 
 	send Output
 		"
-		"[Section]
+		"[@Section]
 		"
 		"%% write data;
 		"
@@ -322,14 +320,9 @@ void zig( Output: stream )
 		"	var cs: i32 = 0;
 		"	var buffer: \[1024\]u8 = undefined;
 		"	var blen: usize = 0;
-		"	var nfa_len: i32 = 0;
-		"	var nfa_count: i32 = 0;
-		"	var nfa_bp_state: \[20\]i32 = .{ 0 } ** 20;
-		"	var nfa_bp_p: \[20\]i32 = .{ 0 } ** 20;
 		"
 		"	_ = &data; _ = &p; _ = &pe; _ = &eof; _ = &cs;
 		"	_ = &buffer; _ = &blen;
-		"	_ = &nfa_len; _ = &nfa_count; _ = &nfa_bp_state; _ = &nfa_bp_p;
 
 	for Stmt: indep::stmt in Init {
 		if match Stmt [ExprStmt: expr_stmt] {
@@ -345,7 +338,7 @@ void zig( Output: stream )
 		"	%% write init;
 		"	%% write exec;
 		"
-		"	if ( cs >= [MachineName.mn_word]_first_final ) {
+		"	if ( cs >= [MachineName.word]_first_final ) {
 		"		_out( \"ACCEPT\\n\", .{} );
 		"	}
 		"	else {

--- a/test/trans.d/trans.lm
+++ b/test/trans.d/trans.lm
@@ -300,6 +300,7 @@ include 'trans-ocaml.lm'
 include 'trans-rust.lm'
 include 'trans-julia.lm'
 include 'trans-crack.lm'
+include 'trans-zig.lm'
 
 str argvPop()
 {
@@ -361,6 +362,8 @@ elsif ( Lang == 'julia' )
 	trans_julia::julia( Output )
 elsif ( Lang == 'crack' )
 	trans_crack::crack( Output )
+elsif ( Lang == 'zig' )
+	trans_zig::zig( Output )
 else {
 	print( 'trans: unrecognized language: ', Lang, '\n' )
 }


### PR DESCRIPTION
Basically just followed in the footsteps of the other major languages. *Should* have all of the relevant components and parts in order, and I verified everything against my Zig 0.16 install (Zig is stricter about things like unreachable code, so this was helpful).

The unique thing here is a clever manipulation of Zig (which doesn't have GOTO statements) to support the GOTO path using labeled switches :) 

Let me know if I missed something !!!